### PR TITLE
feat: delete file from the buffer list

### DIFF
--- a/lua/vuffers/auto-commands/buffers.lua
+++ b/lua/vuffers/auto-commands/buffers.lua
@@ -1,5 +1,4 @@
 local buffers = require("vuffers.buffers")
-local ui = require("vuffers.ui")
 
 local M = {}
 

--- a/lua/vuffers/buffers.lua
+++ b/lua/vuffers/buffers.lua
@@ -53,6 +53,10 @@ function M.set_current_bufnr(buffer, file_type)
   events.publish(events.names.ActiveFileChanged)
 end
 
+local function reset_active_buffer()
+  current = nil
+end
+
 function M.get_current_bufnr()
   return current
 end

--- a/lua/vuffers/config.lua
+++ b/lua/vuffers/config.lua
@@ -5,13 +5,23 @@ local M = {}
 ---@field file_types string[]
 local exclude = {
   file_names = { "term://" },
-  file_types = { "lazygit" },
+  file_types = { "lazygit", "NvimTree" },
+}
+
+---@class Handlers
+---@field on_delete_buffer fun(bufnr: number)
+local handlers = {
+  on_delete_buffer = function(bufnr)
+    vim.api.nvim_command(":bwipeout " .. bufnr)
+  end,
 }
 
 ---@class Config
 ---@field exclude Exclude
+---@field handlers Handlers
 local config = {
   exclude = exclude,
+  handlers = handlers,
 }
 
 M.get_config = function()
@@ -20,6 +30,10 @@ end
 
 M.get_exclude = function()
   return config.exclude
+end
+
+M.get_handlers = function()
+  return config.handlers
 end
 
 return M

--- a/lua/vuffers/key-bindings.lua
+++ b/lua/vuffers/key-bindings.lua
@@ -1,4 +1,5 @@
 local buffers = require("vuffers.buffers")
+local config = require("vuffers.config")
 local M = {}
 
 function M.init(bufnr)
@@ -8,6 +9,21 @@ function M.init(bufnr)
     local buf = buffers.get_buffer_by_index(row)
 
     vim.api.nvim_command("wincmd l" .. "|" .. "buffer " .. buf.buf)
+  end, { noremap = true, silent = true, nowait = true, buffer = bufnr })
+
+  vim.keymap.set("n", "d", function()
+    local pos = vim.api.nvim_win_get_cursor(0)
+    local row = pos[1]
+    local buf = buffers.get_buffer_by_index(row)
+    local active_bufnr = buffers.get_current_bufnr()
+
+    -- TODO: fix the limitation
+    if buf.buf == active_bufnr then
+      return
+    end
+
+    buffers.remove_buffer(buf.buf)
+    config.get_handlers().on_delete_buffer(buf.buf)
   end, { noremap = true, silent = true, nowait = true, buffer = bufnr })
 end
 

--- a/lua/vuffers/window.lua
+++ b/lua/vuffers/window.lua
@@ -29,7 +29,7 @@ function M.init(opts)
     buf_options = {
       swapfile = false,
       buftype = "nofile",
-      -- modifiable = false,
+      modifiable = true,
       filetype = constants.FILE_TYPE,
       bufhidden = "hide",
     },


### PR DESCRIPTION
Add functionality to delete buffer from the buffer list, when pressing the "d" key on the target item on the list.

This will remove the target from the internal buffer list, then actually delete the buffer by provided function (on_delete_buffer) function in the config. By default, it runs `bwipeout` command