### PR TITLE
fix: sort type and order when window is closed

### DIFF
--- a/lua/vuffers/auto-commands/init.lua
+++ b/lua/vuffers/auto-commands/init.lua
@@ -56,7 +56,7 @@ function M.create_auto_group()
     group = constants.AUTO_CMD_GROUP,
     callback = function()
       logger.debug(events.names.SortChanged)
-      buffers.sort_buffers()
+      buffers.change_sort()
     end,
   })
 end

--- a/lua/vuffers/buffer-utils.lua
+++ b/lua/vuffers/buffer-utils.lua
@@ -82,10 +82,6 @@ function M.get_file_names(buffers)
 
   loop(input)
 
-  table.sort(output, function(a, b)
-    return a.index < b.index
-  end)
-
   return list.map(output, function(item)
     return {
       buf = item.buf,

--- a/tests/buffer-utils_spec.lua
+++ b/tests/buffer-utils_spec.lua
@@ -10,6 +10,10 @@ describe("utils", function()
         { path = "test.json", buf = 4 },
       })
 
+      table.sort(res, function(a, b)
+        return a.buf < b.buf
+      end)
+
       res = list.map(res, function(item)
         return item.name
       end)
@@ -25,6 +29,10 @@ describe("utils", function()
         { path = "a/user.ts", buf = 4 },
       })
 
+      table.sort(res, function(a, b)
+        return a.buf < b.buf
+      end)
+
       res = list.map(res, function(item)
         return item.name
       end)
@@ -38,6 +46,10 @@ describe("utils", function()
         { path = "user.ts", buf = 2 },
       })
 
+      table.sort(res, function(a, b)
+        return a.buf < b.buf
+      end)
+
       res = list.map(res, function(item)
         return item.name
       end)
@@ -50,6 +62,10 @@ describe("utils", function()
         { path = "user.ts", buf = 1 },
         { path = "b/user.ts", buf = 2 },
       })
+
+      table.sort(res, function(a, b)
+        return a.buf < b.buf
+      end)
 
       res = list.map(res, function(item)
         return item.name
@@ -65,6 +81,10 @@ describe("utils", function()
         { path = "x/a/test.ts", buf = 3 },
       })
 
+      table.sort(res, function(a, b)
+        return a.buf < b.buf
+      end)
+
       res = list.map(res, function(item)
         return item.name
       end)
@@ -79,6 +99,10 @@ describe("utils", function()
         { path = "m/n/b.ts", buf = 3 },
         { path = "c/b.ts", buf = 4 },
       })
+
+      table.sort(res, function(a, b)
+        return a.buf < b.buf
+      end)
 
       res = list.map(res, function(item)
         return item.name


### PR DESCRIPTION
When vuffer window is reopened, the sort type and order are reset. They should remain.