### PR TITLE
feat: show parent folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,6 @@
 run-tests:
 	nvim --headless -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal_init.lua', sequential = true}"
+
+run-test:
+	nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedFile $(filter-out $@,$(MAKECMDGOALS))"
+

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,2 @@
 run-tests:
-	nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal_init.lua', sequential = true}"
- 	
+	nvim --headless -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal_init.lua', sequential = true}"

--- a/README.md
+++ b/README.md
@@ -120,13 +120,15 @@ return {
 
 ## 🔫 Usage
 
-| function              | param                                                       | description                                                                                                                |
-| --------------------- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| go_to_buffer_by_count | {direction: 'next' \| 'prev', count?: integer }             | open the next or previous buffer in the vuffers list. works with v count                                                   |
-| go_to_buffer_by_line  | line_number?: integer                                       | open the buffer on the specified line. works with line number                                                              |
-| sort                  | {type: 'none' \| 'filename', direction: 'asc' \| 'desc' }   | sort the vuffers list                                                                                                      |
-| resize                | width: string \| number                                     | resize vuffers list window. If string such as "+10" or "-10" passed, the window size is increased or decreased accordingly |
-| set_log_level         | level: 'error' \| 'warning' \| 'info' \| 'debug' \| 'trace' | update log level                                                                                                           |
+| function                            | param                                                         | description                                                                                                                |
+| ----------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `go_to_buffer_by_count`             | `{direction: 'next' \| 'prev', count?: integer }`             | open the next or previous buffer in the vuffers list. works with v count                                                   |
+| `go_to_buffer_by_line`              | `line_number?: integer`                                       | open the buffer on the specified line. works with line number                                                              |
+| `sort`                              | `{type: 'none' \| 'filename', direction: 'asc' \| 'desc' }`   | sort the vuffers list                                                                                                      |
+| `resize`                            | `width: string \| number`                                     | resize vuffers list window. If string such as "+10" or "-10" passed, the window size is increased or decreased accordingly |
+| `increment_additional_folder_depth` |                                                               | show extra parent folder. however, sorting is still based on the filename (e.g. "something" for "a/b/c/something.json")    |
+| `decrement_additional_folder_depth` |                                                               | opposite of `increment_additional_folder_depth`                                                                            |
+| `set_log_level`                     | `level: 'error' \| 'warning' \| 'info' \| 'debug' \| 'trace'` | update log level                                                                                                           |
 
 <br>
 
@@ -147,6 +149,6 @@ return {
   - for example `a/b/c.json` and `a/b/d.json` are grouped and sorted by `b`
 - toggle full path from cwd
 - filter by name
-- bookmark a buffer
+- pin a buffer
 - (show Git signs)
 - (show LSP diagnostics)

--- a/lua/utils/list.lua
+++ b/lua/utils/list.lua
@@ -60,7 +60,7 @@ function M.find_index(arr, predicate)
   return nil
 end
 
-function M.slice_array(arr, start_index, end_index)
+function M.slice(arr, start_index, end_index)
   local sliced_arr = {}
   for i = start_index, end_index do
     table.insert(sliced_arr, arr[i])

--- a/lua/utils/string.lua
+++ b/lua/utils/string.lua
@@ -9,4 +9,10 @@ function M.split(str, separator)
   return arr
 end
 
+function M.replace(str, what, with)
+  what = string.gsub(what, "[%(%)%.%+%-%*%?%[%]%^%$%%]", "%%%1") -- escape pattern
+  with = string.gsub(with, "[%%]", "%%%%") -- escape replacement
+  return string.gsub(str, what, with)
+end
+
 return M

--- a/lua/utils/string.lua
+++ b/lua/utils/string.lua
@@ -1,0 +1,12 @@
+local M = {}
+
+function M.split(str, separator)
+  local arr = {}
+  local pattern = string.format("([^%s]+)", separator)
+  str:gsub(pattern, function(substring)
+    table.insert(arr, substring)
+  end)
+  return arr
+end
+
+return M

--- a/lua/vuffers.lua
+++ b/lua/vuffers.lua
@@ -19,6 +19,11 @@ function M.setup(opts)
   logger.debug("setup end")
 end
 
+---@return boolean
+function M.is_open()
+  return window.is_open()
+end
+
 function M.toggle()
   if window.is_open() then
     M.close()

--- a/lua/vuffers.lua
+++ b/lua/vuffers.lua
@@ -96,13 +96,15 @@ function M.resize(width)
 end
 
 function M.increment_additional_folder_depth()
-  logger.debug("increment_additional_folder_depth")
+  logger.debug("increment_additional_folder_depth: start")
   bufs.increment_additional_folder_depth()
+  logger.info("increment_additional_folder_depth: done")
 end
 
 function M.decrement_additional_folder_depth()
-  logger.debug("decrement_additional_folder_depth")
+  logger.debug("decrement_additional_folder_depth: start")
   bufs.decrement_additional_folder_depth()
+  logger.info("decrement_additional_folder_depth: done")
 end
 
 return M

--- a/lua/vuffers.lua
+++ b/lua/vuffers.lua
@@ -95,4 +95,9 @@ function M.resize(width)
   window.resize(width)
 end
 
+---@param value integer
+function M.change_level(value)
+  bufs.change_level(value)
+end
+
 return M

--- a/lua/vuffers.lua
+++ b/lua/vuffers.lua
@@ -95,9 +95,14 @@ function M.resize(width)
   window.resize(width)
 end
 
----@param value integer
-function M.change_level(value)
-  bufs.change_level(value)
+function M.increment_additional_folder_depth()
+  logger.debug("increment_additional_folder_depth")
+  bufs.increment_additional_folder_depth()
+end
+
+function M.decrement_additional_folder_depth()
+  logger.debug("decrement_additional_folder_depth")
+  bufs.decrement_additional_folder_depth()
 end
 
 return M

--- a/lua/vuffers/buffer-utils.lua
+++ b/lua/vuffers/buffer-utils.lua
@@ -87,7 +87,7 @@ local function _format_buffer(item)
   return b
 end
 
---- @param buffers { buf:integer, name: string, path: string, additional_folder_depth?: integer }[]
+--- @param buffers { buf:integer, name: string, path: string, _additional_folder_depth?: integer }[]
 --- @return Buffer[]
 function M.get_formatted_buffers(buffers)
   local output = {}
@@ -99,7 +99,7 @@ function M.get_formatted_buffers(buffers)
       path = buffer.path,
       level = 1,
       path_fragments = str.split(buffer.path, "/"),
-      additional_folder_depth = buffer.additional_folder_depth,
+      additional_folder_depth = buffer._additional_folder_depth,
     }
   end)
 

--- a/lua/vuffers/buffer-utils.lua
+++ b/lua/vuffers/buffer-utils.lua
@@ -87,7 +87,7 @@ local function _format_buffer(item)
   return b
 end
 
---- @param buffers { buf:integer, name: string, path: string, _additional_folder_depth?: integer }[]
+--- @param buffers { buf:integer,  path: string, _additional_folder_depth?: integer }[]
 --- @return Buffer[]
 function M.get_formatted_buffers(buffers)
   local output = {}

--- a/lua/vuffers/buffer-utils.lua
+++ b/lua/vuffers/buffer-utils.lua
@@ -86,24 +86,27 @@ local function _format_buffer(item)
     _unique_name = unique_name_without_extension,
     _additional_folder_depth = item.additional_folder_depth,
     _default_folder_depth = item.level,
+    _max_folder_depth = #item.path_fragments,
   }
 
   return b
 end
 
 --- @param buffers { buf:integer,  path: string, _additional_folder_depth?: integer }[]
---- @return Buffer[]
+--- @return Buffer[] buffers
 function M.get_formatted_buffers(buffers)
   local cwd = vim.loop.cwd()
   local output = {}
 
   -- preparing the input. adding extra data
   local input = list.map(buffers, function(buffer, i)
+    local path_from_cwd = str.replace(buffer.path, (cwd or "") .. "/", "")
+    local path_fragments = str.split(path_from_cwd, "/")
     return {
       buf = buffer.buf,
       path = str.replace(buffer.path, (cwd or "") .. "/", ""),
       level = 1,
-      path_fragments = str.split(buffer.path, "/"),
+      path_fragments = path_fragments,
       additional_folder_depth = buffer._additional_folder_depth,
     }
   end)

--- a/lua/vuffers/buffer-utils.lua
+++ b/lua/vuffers/buffer-utils.lua
@@ -2,9 +2,20 @@ local list = require("utils.list")
 local logger = require("utils.logger")
 local config = require("vuffers.config")
 local constants = require("vuffers.constants")
-local plenary = require("plenary")
+local str = require("utils.string")
 
 local M = {}
+
+function M.get_name_by_level(filename, level)
+  local items = str.split(filename, "/")
+
+  if #items <= level then
+    return filename
+  end
+
+  local filenames = list.slice(items, #items - level + 1, #items)
+  return table.concat(filenames, "/")
+end
 
 --- @param buffers { buf:integer, name: string, path: string }[]
 --- @return Buffer[]
@@ -19,6 +30,7 @@ function M.get_file_names(buffers)
       buf = buffer.buf,
       index = i,
       path = buffer.path,
+      level = 0,
     }
   end)
 
@@ -47,6 +59,7 @@ function M.get_file_names(buffers)
           name = filename,
           buf = item.buf,
           path = item.path,
+          -- level = item.level + 1,
         }
 
         table.insert(output, filename_with_index)

--- a/lua/vuffers/buffer-utils.lua
+++ b/lua/vuffers/buffer-utils.lua
@@ -30,7 +30,7 @@ function M.get_file_names(buffers)
       buf = buffer.buf,
       index = i,
       path = buffer.path,
-      level = 0,
+      default_level = 0,
     }
   end)
 
@@ -59,7 +59,7 @@ function M.get_file_names(buffers)
           name = filename,
           buf = item.buf,
           path = item.path,
-          -- level = item.level + 1,
+          default_level = item.default_level + 1,
         }
 
         table.insert(output, filename_with_index)
@@ -77,6 +77,7 @@ function M.get_file_names(buffers)
             name = filename,
             buf = item.buf,
             path = item.path,
+            default_level = item.default_level + 1,
           })
         else
           table.insert(next_items, {
@@ -85,6 +86,7 @@ function M.get_file_names(buffers)
             index = item.index,
             buf = item.buf,
             path = item.path,
+            default_level = item.default_level + 1,
           })
         end
       end
@@ -112,6 +114,7 @@ function M.get_file_names(buffers)
       name = name_without_extension,
       path = item.path,
       ext = extension or "",
+      default_level = item.default_level,
     }
   end)
 end

--- a/lua/vuffers/buffers.lua
+++ b/lua/vuffers/buffers.lua
@@ -15,6 +15,7 @@ local constants = require("vuffers.constants")
 ---@field _unique_name string unique name to be used for sorting
 ---@field _default_folder_depth number
 ---@field _additional_folder_depth number
+---@field _max_folder_depth number
 
 ---@class NativeBuffer
 ---@field buf number
@@ -194,7 +195,11 @@ local function _change_additional_folder_depth(new_level)
 end
 
 function M.increment_additional_folder_depth()
-  local new_level = math.max(_global_additional_folder_depth + 1, 0)
+  local max_folder_depths = list.map(_buf_list, function(buf)
+    return buf._max_folder_depth
+  end)
+  local max_additional_folder_depth = math.max(unpack(max_folder_depths)) - 1
+  local new_level = math.min(_global_additional_folder_depth + 1, max_additional_folder_depth)
   _change_additional_folder_depth(new_level)
 end
 

--- a/lua/vuffers/buffers.lua
+++ b/lua/vuffers/buffers.lua
@@ -166,6 +166,37 @@ function M.change_sort()
   event_bus.publish_buffer_list_changed(payload)
 end
 
+---@type number | nil How many more parents the UI shows. This can not go below 0
+local _level = 0
+
+---@param num integer
+function M.change_level(num)
+  local new_level = math.max(_level + num, 0)
+
+  if new_level == _level then
+    logger.debug("change_level: level is not changed")
+    return
+  end
+
+  _level = new_level
+
+  local bufs = list.map(_get_formatted_buffers(), function(buf)
+    local target_level = new_level + 1
+    if target_level > buf.default_level then
+      buf.name = utils.get_name_by_level(buf.path, target_level)
+    end
+    return buf
+  end)
+
+  utils.sort_buffers(bufs, config.get_sort())
+  _buf_list = bufs
+
+  local payload = _get_buffer_list_changed_event_payload()
+  logger.debug("change_level: level changed", { new_level = new_level })
+
+  event_bus.publish_buffer_list_changed(payload)
+end
+
 function M.reload_all_buffers()
   reset_buffers()
 

--- a/lua/vuffers/buffers.lua
+++ b/lua/vuffers/buffers.lua
@@ -167,41 +167,38 @@ function M.change_sort()
 end
 
 ---@type number | nil How many more parents the UI shows. This can not go below 0
-local _additional_folder_depth = 0
+local _global_additional_folder_depth = 0
 
 ---@param new_level integer
 local function _change_additional_folder_depth(new_level)
-  if new_level == _additional_folder_depth then
+  if new_level == _global_additional_folder_depth then
     logger.debug("change_level: level is not changed")
     return
   end
 
-  _additional_folder_depth = new_level
-
-  local bufs = list.map(utils.get_formatted_buffers(_buf_list), function(buf)
-    local target_level = new_level + 1
-    if target_level > buf.default_level then
-      buf.name = utils.get_name_by_level(buf.path, target_level)
-    end
+  local bufs = list.map(_buf_list, function(buf)
+    buf._additional_folder_depth = new_level
     return buf
   end)
-
+  bufs = utils.get_formatted_buffers(bufs)
   utils.sort_buffers(bufs, config.get_sort())
   _buf_list = bufs
 
   local payload = _get_buffer_list_changed_event_payload()
+
+  _global_additional_folder_depth = new_level
   logger.debug("change_level: level changed", { new_level = new_level })
 
   event_bus.publish_buffer_list_changed(payload)
 end
 
 function M.increment_additional_folder_depth()
-  local new_level = math.max(_additional_folder_depth + 1, 0)
+  local new_level = math.max(_global_additional_folder_depth + 1, 0)
   _change_additional_folder_depth(new_level)
 end
 
 function M.decrement_additional_folder_depth()
-  local new_level = math.max(_additional_folder_depth - 1, 0)
+  local new_level = math.max(_global_additional_folder_depth - 1, 0)
   _change_additional_folder_depth(new_level)
 end
 

--- a/lua/vuffers/buffers.lua
+++ b/lua/vuffers/buffers.lua
@@ -167,18 +167,16 @@ function M.change_sort()
 end
 
 ---@type number | nil How many more parents the UI shows. This can not go below 0
-local _level = 0
+local _additional_folder_depth = 0
 
----@param num integer
-function M.change_level(num)
-  local new_level = math.max(_level + num, 0)
-
-  if new_level == _level then
+---@param new_level integer
+local function _change_additional_folder_depth(new_level)
+  if new_level == _additional_folder_depth then
     logger.debug("change_level: level is not changed")
     return
   end
 
-  _level = new_level
+  _additional_folder_depth = new_level
 
   local bufs = list.map(_get_formatted_buffers(), function(buf)
     local target_level = new_level + 1
@@ -195,6 +193,16 @@ function M.change_level(num)
   logger.debug("change_level: level changed", { new_level = new_level })
 
   event_bus.publish_buffer_list_changed(payload)
+end
+
+function M.increment_additional_folder_depth()
+  local new_level = math.max(_additional_folder_depth + 1, 0)
+  _change_additional_folder_depth(new_level)
+end
+
+function M.decrement_additional_folder_depth()
+  local new_level = math.max(_additional_folder_depth - 1, 0)
+  _change_additional_folder_depth(new_level)
 end
 
 function M.reload_all_buffers()

--- a/lua/vuffers/buffers.lua
+++ b/lua/vuffers/buffers.lua
@@ -12,6 +12,7 @@ local constants = require("vuffers.constants")
 ---@field name string
 ---@field path string: full path of
 ---@field ext string
+---@field default_level number
 
 ---@class NativeBuffer
 ---@field buf number

--- a/tests/buffer-utils_spec.lua
+++ b/tests/buffer-utils_spec.lua
@@ -78,6 +78,9 @@ describe("utils", function()
         { path = "test.json", buf = 3 },
         { path = ".eslintrc", buf = 4 },
         { path = "Dockerfile", buf = 5 },
+        { path = "a/b/c/d", buf = 6 },
+        { path = "x/b/c/d", buf = 7 },
+        { path = "b/c/d", buf = 8 },
       })
 
       table.sort(res, function(a, b)
@@ -88,7 +91,7 @@ describe("utils", function()
         return item.default_level
       end)
 
-      assert.are.same({ 2, 2, 1, 1, 1 }, extensions)
+      assert.are.same({ 2, 2, 1, 1, 1, 4, 4, 3 }, extensions)
     end)
 
     it("returns correct extension", function()

--- a/tests/buffer-utils_spec.lua
+++ b/tests/buffer-utils_spec.lua
@@ -1,77 +1,78 @@
 ---@diagnostic disable: undefined-global
 local utils = require("vuffers.buffer-utils")
+local str = require("utils.string")
 local list = require("utils.list")
 local constants = require("vuffers.constants")
 
 describe("utils", function()
   describe("get_file_name_by_level", function()
     it("get filename when level = 1", function()
-      local file = "a/b/c/d.test.ts"
+      local file = str.split("a/b/c/d.test.ts", "/")
       local level = 1
 
-      local res = utils.get_name_by_level(file, level)
+      local res = utils._get_name_by_level(file, level)
 
       assert.equals("d.test.ts", res)
     end)
 
     it("get filename when level = 1 and file does not have extension", function()
-      local file = "a/b/c/Dockerfile"
+      local file = str.split("a/b/c/Dockerfile", "/")
       local level = 1
 
-      local res = utils.get_name_by_level(file, level)
+      local res = utils._get_name_by_level(file, level)
 
       assert.equals("Dockerfile", res)
     end)
 
     it("get filename when level = 1 and file starts with dot (.)", function()
-      local file = "a/b/c/.eslintrc"
+      local file = str.split("a/b/c/.eslintrc", "/")
       local level = 1
 
-      local res = utils.get_name_by_level(file, level)
+      local res = utils._get_name_by_level(file, level)
 
       assert.equals(".eslintrc", res)
     end)
 
     it("get filename when level = 2", function()
-      local file = "a/b/c/d.test.ts"
+      local file = str.split("a/b/c/d.test.ts", "/")
       local level = 2
 
-      local res = utils.get_name_by_level(file, level)
+      local res = utils._get_name_by_level(file, level)
 
       print(res)
       assert.equals("c/d.test.ts", res)
     end)
 
     it("get filename when level = 2 and file does not have extention", function()
-      local file = "a/b/c/Dockerfile"
+      local file = str.split("a/b/c/Dockerfile", "/")
       local level = 2
 
-      local res = utils.get_name_by_level(file, level)
+      local res = utils._get_name_by_level(file, level)
 
       assert.equals("c/Dockerfile", res)
     end)
 
     it("get filename when level = 2 and file starts with dot (.)", function()
-      local file = "a/b/c/.eslintrc"
+      local file = str.split("a/b/c/.eslintrc", "/")
       local level = 2
 
-      local res = utils.get_name_by_level(file, level)
+      local res = utils._get_name_by_level(file, level)
 
       assert.equals("c/.eslintrc", res)
     end)
 
     it("get the original filename when level is greater than the actual filename", function()
-      local file = "d.test.ts"
+      local file = str.split("d.test.ts", "/")
       local level = 2
 
-      local res = utils.get_name_by_level(file, level)
+      local res = utils._get_name_by_level(file, level)
 
       assert.equals("d.test.ts", res)
     end)
   end)
 
-  describe("get_file_names", function()
-    it("returns correct folder depth", function()
+  describe("get_formatted_buffers", function()
+    it("returns correct default folder depth", function()
       local res = utils.get_formatted_buffers({
         { path = "a/some.ts", buf = 1 },
         { path = "a/b/c/some.ts", buf = 2 },
@@ -116,11 +117,12 @@ describe("utils", function()
 
     it("returns correct filenames when additional folder depth is specified", function()
       local res = utils.get_formatted_buffers({
-        { path = "a/hi.ts", _additional_folder_depth = 1, buf = 1 },
-        { path = "a/b/c/d.lua", _additional_folder_depth = 1, buf = 2 },
-        { path = "test.json", _additional_folder_depth = 1, buf = 3 },
-        { path = ".eslintrc", _additional_folder_depth = 1, buf = 4 },
-        { path = "Dockerfile", _additional_folder_depth = 1, buf = 5 },
+        { path = "a/hi.ts", _additional_folder_depth = 100, buf = 1 },
+        { path = "a/test.ts", _additional_folder_depth = -100, buf = 2 },
+        { path = "a/b/c/d.lua", _additional_folder_depth = 3, buf = 3 },
+        { path = "test.json", _additional_folder_depth = 1, buf = 4 },
+        { path = ".eslintrc", _additional_folder_depth = 1, buf = 5 },
+        { path = "Dockerfile", _additional_folder_depth = 1, buf = 6 },
       })
 
       table.sort(res, function(a, b)
@@ -131,7 +133,7 @@ describe("utils", function()
         return item.name
       end)
 
-      assert.are.same({ "a/hi", "c/d", "test", ".eslintrc", "Dockerfile" }, extensions)
+      assert.are.same({ "a/hi", "test", "a/b/c/d", "test", ".eslintrc", "Dockerfile" }, extensions)
     end)
 
     it("returns correct filenames when the filenames of the input is unique", function()

--- a/tests/buffer-utils_spec.lua
+++ b/tests/buffer-utils_spec.lua
@@ -5,6 +5,26 @@ local constants = require("vuffers.constants")
 
 describe("utils", function()
   describe("get_file_names", function()
+    it("returns correct extension #only", function()
+      local res = utils.get_file_names({
+        { path = "a/hi.ts", buf = 1 },
+        { path = "a/b/c/d.lua", buf = 2 },
+        { path = "test.json", buf = 3 },
+        { path = ".eslintrc", buf = 4 },
+        { path = "Dockerfile", buf = 5 },
+      })
+
+      table.sort(res, function(a, b)
+        return a.buf < b.buf
+      end)
+
+      local extensions = list.map(res, function(item)
+        return item.ext
+      end)
+
+      assert.are.same({ "ts", "lua", "json", "eslintrc", "" }, extensions)
+    end)
+
     it("returns correct filenames when the filenames of the input is unique", function()
       local res = utils.get_file_names({
         { path = "a/hi.ts", buf = 1 },
@@ -24,12 +44,7 @@ describe("utils", function()
         return item.name
       end)
 
-      local extensions = list.map(res, function(item)
-        return item.ext
-      end)
-
       assert.are.same({ "hi", "user", "user.test", "test", "test", ".eslintrc", "Dockerfile" }, filenames)
-      assert.are.same({ "ts", "ts", "ts", "js", "json", "eslintrc", nil }, extensions)
     end)
 
     it("returns correct filenames when the filenames of the input has duplicate. case 1", function()

--- a/tests/buffer-utils_spec.lua
+++ b/tests/buffer-utils_spec.lua
@@ -4,6 +4,72 @@ local list = require("utils.list")
 local constants = require("vuffers.constants")
 
 describe("utils", function()
+  describe("get_file_name_by_level", function()
+    it("get filename when level = 1", function()
+      local file = "a/b/c/d.test.ts"
+      local level = 1
+
+      local res = utils.get_name_by_level(file, level)
+
+      assert.equals("d.test.ts", res)
+    end)
+
+    it("get filename when level = 1 and file does not have extention", function()
+      local file = "a/b/c/Dockerfile"
+      local level = 1
+
+      local res = utils.get_name_by_level(file, level)
+
+      assert.equals("Dockerfile", res)
+    end)
+
+    it("get filename when level = 1 and file starts with dot (.)", function()
+      local file = "a/b/c/.eslintrc"
+      local level = 1
+
+      local res = utils.get_name_by_level(file, level)
+
+      assert.equals(".eslintrc", res)
+    end)
+
+    it("get filename when level = 2", function()
+      local file = "a/b/c/d.test.ts"
+      local level = 2
+
+      local res = utils.get_name_by_level(file, level)
+
+      print(res)
+      assert.equals("c/d.test.ts", res)
+    end)
+
+    it("get filename when level = 2 and file does not have extention", function()
+      local file = "a/b/c/Dockerfile"
+      local level = 2
+
+      local res = utils.get_name_by_level(file, level)
+
+      assert.equals("c/Dockerfile", res)
+    end)
+
+    it("get filename when level = 2 and file starts with dot (.)", function()
+      local file = "a/b/c/.eslintrc"
+      local level = 2
+
+      local res = utils.get_name_by_level(file, level)
+
+      assert.equals("c/.eslintrc", res)
+    end)
+
+    it("get the original filename when level is greater than the actual filename", function()
+      local file = "d.test.ts"
+      local level = 2
+
+      local res = utils.get_name_by_level(file, level)
+
+      assert.equals("d.test.ts", res)
+    end)
+  end)
+
   describe("get_file_names", function()
     it("returns correct extension #only", function()
       local res = utils.get_file_names({

--- a/tests/buffer-utils_spec.lua
+++ b/tests/buffer-utils_spec.lua
@@ -114,6 +114,26 @@ describe("utils", function()
       assert.are.same({ "ts", "lua", "json", "eslintrc", "" }, extensions)
     end)
 
+    it("returns correct filenames when additional folder depth is specified", function()
+      local res = utils.get_formatted_buffers({
+        { path = "a/hi.ts", additional_folder_depth = 1, buf = 1 },
+        { path = "a/b/c/d.lua", additional_folder_depth = 1, buf = 2 },
+        { path = "test.json", additional_folder_depth = 1, buf = 3 },
+        { path = ".eslintrc", additional_folder_depth = 1, buf = 4 },
+        { path = "Dockerfile", additional_folder_depth = 1, buf = 5 },
+      })
+
+      table.sort(res, function(a, b)
+        return a.buf < b.buf
+      end)
+
+      local extensions = list.map(res, function(item)
+        return item.name
+      end)
+
+      assert.are.same({ "a/hi", "c/d", "test", ".eslintrc", "Dockerfile" }, extensions)
+    end)
+
     it("returns correct filenames when the filenames of the input is unique", function()
       local res = utils.get_formatted_buffers({
         { path = "a/hi.ts", buf = 1 },

--- a/tests/buffer-utils_spec.lua
+++ b/tests/buffer-utils_spec.lua
@@ -14,7 +14,7 @@ describe("utils", function()
       assert.equals("d.test.ts", res)
     end)
 
-    it("get filename when level = 1 and file does not have extention", function()
+    it("get filename when level = 1 and file does not have extension", function()
       local file = "a/b/c/Dockerfile"
       local level = 1
 
@@ -71,8 +71,8 @@ describe("utils", function()
   end)
 
   describe("get_file_names", function()
-    it("returns correct level", function()
-      local res = utils.get_file_names({
+    it("returns correct folder depth", function()
+      local res = utils.get_formatted_buffers({
         { path = "a/some.ts", buf = 1 },
         { path = "a/b/c/some.ts", buf = 2 },
         { path = "test.json", buf = 3 },
@@ -88,14 +88,14 @@ describe("utils", function()
       end)
 
       local extensions = list.map(res, function(item)
-        return item.default_level
+        return item._default_folder_depth
       end)
 
       assert.are.same({ 2, 2, 1, 1, 1, 4, 4, 3 }, extensions)
     end)
 
     it("returns correct extension", function()
-      local res = utils.get_file_names({
+      local res = utils.get_formatted_buffers({
         { path = "a/hi.ts", buf = 1 },
         { path = "a/b/c/d.lua", buf = 2 },
         { path = "test.json", buf = 3 },
@@ -115,7 +115,7 @@ describe("utils", function()
     end)
 
     it("returns correct filenames when the filenames of the input is unique", function()
-      local res = utils.get_file_names({
+      local res = utils.get_formatted_buffers({
         { path = "a/hi.ts", buf = 1 },
         { path = "b/user.ts", buf = 2 },
         { path = "b/user.test.ts", buf = 3 },
@@ -137,7 +137,7 @@ describe("utils", function()
     end)
 
     it("returns correct filenames when the filenames of the input has duplicate. case 1", function()
-      local res = utils.get_file_names({
+      local res = utils.get_formatted_buffers({
         { path = "hi.ts", buf = 1 },
         { path = "b/user.ts", buf = 2 },
         { path = "a/test.ts", buf = 3 },
@@ -157,7 +157,7 @@ describe("utils", function()
     end)
 
     it("returns correct filenames when the filenames of the input has duplicate. case 2", function()
-      local res = utils.get_file_names({
+      local res = utils.get_formatted_buffers({
         { path = "b/user.ts", buf = 1 },
         { path = "user.ts", buf = 2 },
       })
@@ -174,7 +174,7 @@ describe("utils", function()
     end)
 
     it("returns correct filenames when the filenames of the input has duplicate. case 3", function()
-      local res = utils.get_file_names({
+      local res = utils.get_formatted_buffers({
         { path = "user.ts", buf = 1 },
         { path = "b/user.ts", buf = 2 },
       })
@@ -191,7 +191,7 @@ describe("utils", function()
     end)
 
     it("returns correct filenames when the filenames of the input has multiple duplicate. case 4", function()
-      local res = utils.get_file_names({
+      local res = utils.get_formatted_buffers({
         { path = "a/user.ts", buf = 1 },
         { path = "b/user.ts", buf = 2 },
         { path = "x/a/test.ts", buf = 3 },
@@ -209,7 +209,7 @@ describe("utils", function()
     end)
 
     it("returns correct filenames when the filenames of the input has multiple duplicate. case 5", function()
-      local res = utils.get_file_names({
+      local res = utils.get_formatted_buffers({
         { path = "a/b.ts", buf = 1 },
         { path = "x/a/b.ts", buf = 2 },
         { path = "m/n/b.ts", buf = 3 },
@@ -230,20 +230,21 @@ describe("utils", function()
 
   describe("sort_buffers", function()
     it("should sort by filename", function()
+      ---@type Buffer[]
       local bufs = {
         {
           buf = 4,
-          name = "some.test",
+          _unique_name = "some.test",
           ext = "ts",
         },
         {
           buf = 6,
-          name = "main",
+          _unique_name = "main",
           ext = "ts",
         },
         {
           buf = 5,
-          name = "some",
+          _unique_name = "some",
           ext = "ts",
         },
       }
@@ -252,7 +253,7 @@ describe("utils", function()
         utils.sort_buffers(bufs, { type = constants.SORT_TYPE.FILENAME, direction = constants.SORT_DIRECTION.ASC })
 
       res = list.map(bufs, function(item)
-        return item.name
+        return item._unique_name
       end)
 
       assert.are.same(res, { "main", "some", "some.test" })

--- a/tests/buffer-utils_spec.lua
+++ b/tests/buffer-utils_spec.lua
@@ -71,7 +71,27 @@ describe("utils", function()
   end)
 
   describe("get_file_names", function()
-    it("returns correct extension #only", function()
+    it("returns correct level", function()
+      local res = utils.get_file_names({
+        { path = "a/some.ts", buf = 1 },
+        { path = "a/b/c/some.ts", buf = 2 },
+        { path = "test.json", buf = 3 },
+        { path = ".eslintrc", buf = 4 },
+        { path = "Dockerfile", buf = 5 },
+      })
+
+      table.sort(res, function(a, b)
+        return a.buf < b.buf
+      end)
+
+      local extensions = list.map(res, function(item)
+        return item.default_level
+      end)
+
+      assert.are.same({ 2, 2, 1, 1, 1 }, extensions)
+    end)
+
+    it("returns correct extension", function()
       local res = utils.get_file_names({
         { path = "a/hi.ts", buf = 1 },
         { path = "a/b/c/d.lua", buf = 2 },

--- a/tests/buffer-utils_spec.lua
+++ b/tests/buffer-utils_spec.lua
@@ -116,11 +116,11 @@ describe("utils", function()
 
     it("returns correct filenames when additional folder depth is specified", function()
       local res = utils.get_formatted_buffers({
-        { path = "a/hi.ts", additional_folder_depth = 1, buf = 1 },
-        { path = "a/b/c/d.lua", additional_folder_depth = 1, buf = 2 },
-        { path = "test.json", additional_folder_depth = 1, buf = 3 },
-        { path = ".eslintrc", additional_folder_depth = 1, buf = 4 },
-        { path = "Dockerfile", additional_folder_depth = 1, buf = 5 },
+        { path = "a/hi.ts", _additional_folder_depth = 1, buf = 1 },
+        { path = "a/b/c/d.lua", _additional_folder_depth = 1, buf = 2 },
+        { path = "test.json", _additional_folder_depth = 1, buf = 3 },
+        { path = ".eslintrc", _additional_folder_depth = 1, buf = 4 },
+        { path = "Dockerfile", _additional_folder_depth = 1, buf = 5 },
       })
 
       table.sort(res, function(a, b)


### PR DESCRIPTION
This PR adds incrementing the additional folder depth, which allows the user to see more of the file path. 

For example, if the current file is located at `a/b/c/something.json`, `something` is displayed. Incrementing the additional folder depth will display the parent folder in the file name, such as 
`c/something`

It's important to note that this change does not affect the sort order, which is still based on the unique filename (`something` in this case). Additionally, the project now also supports decrementing the additional folder depth.