### PR TITLE
fix:  sort by filename functionality

### DIFF
--- a/lua/utils/list.lua
+++ b/lua/utils/list.lua
@@ -24,6 +24,7 @@ end
 --- @param arr TItem[]
 --- @param predicate fun(item: TItem, index: number): boolean
 --- @return TItem[] | nil
+--- returns non empty list
 function M.filter(arr, predicate)
   local filtered = {}
   for i, v in ipairs(arr) do

--- a/lua/vuffers/buffers.lua
+++ b/lua/vuffers/buffers.lua
@@ -9,10 +9,11 @@ local constants = require("vuffers.constants")
 
 ---@class Buffer
 ---@field buf number
----@field name string name that will be shown in the buffer list
+---@field name string name that will be displayed in the buffer list, which considers additional folder depth
 ---@field path string full path
 ---@field ext string
----@field _unique_name string unique name to be used for sorting
+---@field _unique_name string unique name
+---@field _filename string filename ("test" in "test.txt")
 ---@field _default_folder_depth number
 ---@field _additional_folder_depth number
 ---@field _max_folder_depth number

--- a/lua/vuffers/constants.lua
+++ b/lua/vuffers/constants.lua
@@ -7,6 +7,7 @@ M.VUFFERS_FILE_TYPE = "vuffers"
 M.SORT_TYPE = {
   NONE = "none",
   FILENAME = "filename",
+  UNIQUE_NAME = "unique-name",
 }
 
 ---@enum SortDirection

--- a/tests/buffer-utils_spec.lua
+++ b/tests/buffer-utils_spec.lua
@@ -72,201 +72,243 @@ describe("utils", function()
   end)
 
   describe("get_formatted_buffers", function()
-    it("returns correct default folder depth", function()
-      local res = utils.get_formatted_buffers({
-        { path = "a/some.ts", buf = 1 },
-        { path = "a/b/c/some.ts", buf = 2 },
-        { path = "test.json", buf = 3 },
-        { path = ".eslintrc", buf = 4 },
-        { path = "Dockerfile", buf = 5 },
-        { path = "a/b/c/d", buf = 6 },
-        { path = "x/b/c/d", buf = 7 },
-        { path = "b/c/d", buf = 8 },
-      })
+    describe("folder depth", function()
+      it("returns correct default folder depth", function()
+        local res = utils.get_formatted_buffers({
+          { path = "a/some.ts", buf = 1 },
+          { path = "a/b/c/some.ts", buf = 2 },
+          { path = "test.json", buf = 3 },
+          { path = ".eslintrc", buf = 4 },
+          { path = "Dockerfile", buf = 5 },
+          { path = "a/b/c/d", buf = 6 },
+          { path = "x/b/c/d", buf = 7 },
+          { path = "b/c/d", buf = 8 },
+        })
 
-      table.sort(res, function(a, b)
-        return a.buf < b.buf
+        table.sort(res, function(a, b)
+          return a.buf < b.buf
+        end)
+
+        local extensions = list.map(res, function(item)
+          return item._default_folder_depth
+        end)
+
+        assert.are.same({ 2, 2, 1, 1, 1, 4, 4, 3 }, extensions)
       end)
-
-      local extensions = list.map(res, function(item)
-        return item._default_folder_depth
-      end)
-
-      assert.are.same({ 2, 2, 1, 1, 1, 4, 4, 3 }, extensions)
     end)
 
-    it("returns correct extension", function()
-      local res = utils.get_formatted_buffers({
-        { path = "a/hi.ts", buf = 1 },
-        { path = "a/b/c/d.lua", buf = 2 },
-        { path = "test.json", buf = 3 },
-        { path = ".eslintrc", buf = 4 },
-        { path = "Dockerfile", buf = 5 },
-      })
+    describe("extension", function()
+      it("returns correct extension", function()
+        local res = utils.get_formatted_buffers({
+          { path = "a/hi.ts", buf = 1 },
+          { path = "a/b/c/d.lua", buf = 2 },
+          { path = "test.json", buf = 3 },
+          { path = ".eslintrc", buf = 4 },
+          { path = "Dockerfile", buf = 5 },
+        })
 
-      table.sort(res, function(a, b)
-        return a.buf < b.buf
+        table.sort(res, function(a, b)
+          return a.buf < b.buf
+        end)
+
+        local extensions = list.map(res, function(item)
+          return item.ext
+        end)
+
+        assert.are.same({ "ts", "lua", "json", "eslintrc", "" }, extensions)
       end)
-
-      local extensions = list.map(res, function(item)
-        return item.ext
-      end)
-
-      assert.are.same({ "ts", "lua", "json", "eslintrc", "" }, extensions)
     end)
 
-    it("returns correct filenames when additional folder depth is specified", function()
-      local res = utils.get_formatted_buffers({
-        { path = "a/hi.ts", _additional_folder_depth = 100, buf = 1 },
-        { path = "a/test.ts", _additional_folder_depth = -100, buf = 2 },
-        { path = "a/b/c/d.lua", _additional_folder_depth = 3, buf = 3 },
-        { path = "test.json", _additional_folder_depth = 1, buf = 4 },
-        { path = ".eslintrc", _additional_folder_depth = 1, buf = 5 },
-        { path = "Dockerfile", _additional_folder_depth = 1, buf = 6 },
-      })
+    describe("display name", function()
+      it("returns correct filenames when additional folder depth is specified", function()
+        local res = utils.get_formatted_buffers({
+          { path = "a/hi.ts", _additional_folder_depth = 100, buf = 1 },
+          { path = "a/test.ts", _additional_folder_depth = -100, buf = 2 },
+          { path = "a/b/c/d.lua", _additional_folder_depth = 3, buf = 3 },
+          { path = "test.json", _additional_folder_depth = 1, buf = 4 },
+          { path = ".eslintrc", _additional_folder_depth = 1, buf = 5 },
+          { path = "Dockerfile", _additional_folder_depth = 1, buf = 6 },
+        })
 
-      table.sort(res, function(a, b)
-        return a.buf < b.buf
+        table.sort(res, function(a, b)
+          return a.buf < b.buf
+        end)
+
+        local extensions = list.map(res, function(item)
+          return item.name
+        end)
+
+        assert.are.same({ "a/hi", "test", "a/b/c/d", "test", ".eslintrc", "Dockerfile" }, extensions)
       end)
 
-      local extensions = list.map(res, function(item)
-        return item.name
+      it("returns correct filenames when the filenames of the input is unique", function()
+        local res = utils.get_formatted_buffers({
+          { path = "a/hi.ts", buf = 1 },
+          { path = "b/user.ts", buf = 2 },
+          { path = "b/user.test.ts", buf = 3 },
+          { path = "a/test.js", buf = 4 },
+          { path = "test.json", buf = 5 },
+          { path = ".eslintrc", buf = 6 },
+          { path = "Dockerfile", buf = 7 },
+        })
+
+        table.sort(res, function(a, b)
+          return a.buf < b.buf
+        end)
+
+        local filenames = list.map(res, function(item)
+          return item.name
+        end)
+
+        assert.are.same({ "hi", "user", "user.test", "test", "test", ".eslintrc", "Dockerfile" }, filenames)
       end)
 
-      assert.are.same({ "a/hi", "test", "a/b/c/d", "test", ".eslintrc", "Dockerfile" }, extensions)
-    end)
+      it("returns correct filenames when the filenames of the input has duplicate. case 1", function()
+        local res = utils.get_formatted_buffers({
+          { path = "hi.ts", buf = 1 },
+          { path = "b/user.ts", buf = 2 },
+          { path = "a/test.ts", buf = 3 },
+          { path = "a/user.ts", buf = 4 },
+          { path = ".eslintrc", buf = 5 },
+        })
 
-    it("returns correct filenames when the filenames of the input is unique", function()
-      local res = utils.get_formatted_buffers({
-        { path = "a/hi.ts", buf = 1 },
-        { path = "b/user.ts", buf = 2 },
-        { path = "b/user.test.ts", buf = 3 },
-        { path = "a/test.js", buf = 4 },
-        { path = "test.json", buf = 5 },
-        { path = ".eslintrc", buf = 6 },
-        { path = "Dockerfile", buf = 7 },
-      })
+        table.sort(res, function(a, b)
+          return a.buf < b.buf
+        end)
 
-      table.sort(res, function(a, b)
-        return a.buf < b.buf
+        res = list.map(res, function(item)
+          return item.name
+        end)
+
+        assert.are.same({ "hi", "b/user", "test", "a/user", ".eslintrc" }, res)
       end)
 
-      local filenames = list.map(res, function(item)
-        return item.name
+      it("returns correct filenames when the filenames of the input has duplicate. case 2", function()
+        local res = utils.get_formatted_buffers({
+          { path = "b/user.ts", buf = 1 },
+          { path = "user.ts", buf = 2 },
+        })
+
+        table.sort(res, function(a, b)
+          return a.buf < b.buf
+        end)
+
+        res = list.map(res, function(item)
+          return item.name .. "." .. item.ext
+        end)
+
+        assert.are.same({ "b/user.ts", "user.ts" }, res)
       end)
 
-      assert.are.same({ "hi", "user", "user.test", "test", "test", ".eslintrc", "Dockerfile" }, filenames)
-    end)
+      it("returns correct filenames when the filenames of the input has duplicate. case 3", function()
+        local res = utils.get_formatted_buffers({
+          { path = "user.ts", buf = 1 },
+          { path = "b/user.ts", buf = 2 },
+        })
 
-    it("returns correct filenames when the filenames of the input has duplicate. case 1", function()
-      local res = utils.get_formatted_buffers({
-        { path = "hi.ts", buf = 1 },
-        { path = "b/user.ts", buf = 2 },
-        { path = "a/test.ts", buf = 3 },
-        { path = "a/user.ts", buf = 4 },
-        { path = ".eslintrc", buf = 5 },
-      })
+        table.sort(res, function(a, b)
+          return a.buf < b.buf
+        end)
 
-      table.sort(res, function(a, b)
-        return a.buf < b.buf
+        res = list.map(res, function(item)
+          return item.name .. "." .. item.ext
+        end)
+
+        assert.are.same({ "user.ts", "b/user.ts" }, res)
       end)
 
-      res = list.map(res, function(item)
-        return item.name
+      it("returns correct filenames when the filenames of the input has multiple duplicate. case 4", function()
+        local res = utils.get_formatted_buffers({
+          { path = "a/user.ts", buf = 1 },
+          { path = "b/user.ts", buf = 2 },
+          { path = "x/a/test.ts", buf = 3 },
+        })
+
+        table.sort(res, function(a, b)
+          return a.buf < b.buf
+        end)
+
+        res = list.map(res, function(item)
+          return item.name .. "." .. item.ext
+        end)
+
+        assert.are.same({ "a/user.ts", "b/user.ts", "test.ts" }, res)
       end)
 
-      assert.are.same({ "hi", "b/user", "test", "a/user", ".eslintrc" }, res)
-    end)
+      it("returns correct filenames when the filenames of the input has multiple duplicate. case 5", function()
+        local res = utils.get_formatted_buffers({
+          { path = "a/b.ts", buf = 1 },
+          { path = "x/a/b.ts", buf = 2 },
+          { path = "m/n/b.ts", buf = 3 },
+          { path = "c/b.ts", buf = 4 },
+        })
 
-    it("returns correct filenames when the filenames of the input has duplicate. case 2", function()
-      local res = utils.get_formatted_buffers({
-        { path = "b/user.ts", buf = 1 },
-        { path = "user.ts", buf = 2 },
-      })
+        table.sort(res, function(a, b)
+          return a.buf < b.buf
+        end)
 
-      table.sort(res, function(a, b)
-        return a.buf < b.buf
+        res = list.map(res, function(item)
+          return item.name .. "." .. item.ext
+        end)
+
+        assert.are.same({ "a/b.ts", "x/a/b.ts", "n/b.ts", "c/b.ts" }, res)
       end)
-
-      res = list.map(res, function(item)
-        return item.name .. "." .. item.ext
-      end)
-
-      assert.are.same({ "b/user.ts", "user.ts" }, res)
-    end)
-
-    it("returns correct filenames when the filenames of the input has duplicate. case 3", function()
-      local res = utils.get_formatted_buffers({
-        { path = "user.ts", buf = 1 },
-        { path = "b/user.ts", buf = 2 },
-      })
-
-      table.sort(res, function(a, b)
-        return a.buf < b.buf
-      end)
-
-      res = list.map(res, function(item)
-        return item.name .. "." .. item.ext
-      end)
-
-      assert.are.same({ "user.ts", "b/user.ts" }, res)
-    end)
-
-    it("returns correct filenames when the filenames of the input has multiple duplicate. case 4", function()
-      local res = utils.get_formatted_buffers({
-        { path = "a/user.ts", buf = 1 },
-        { path = "b/user.ts", buf = 2 },
-        { path = "x/a/test.ts", buf = 3 },
-      })
-
-      table.sort(res, function(a, b)
-        return a.buf < b.buf
-      end)
-
-      res = list.map(res, function(item)
-        return item.name .. "." .. item.ext
-      end)
-
-      assert.are.same({ "a/user.ts", "b/user.ts", "test.ts" }, res)
-    end)
-
-    it("returns correct filenames when the filenames of the input has multiple duplicate. case 5", function()
-      local res = utils.get_formatted_buffers({
-        { path = "a/b.ts", buf = 1 },
-        { path = "x/a/b.ts", buf = 2 },
-        { path = "m/n/b.ts", buf = 3 },
-        { path = "c/b.ts", buf = 4 },
-      })
-
-      table.sort(res, function(a, b)
-        return a.buf < b.buf
-      end)
-
-      res = list.map(res, function(item)
-        return item.name .. "." .. item.ext
-      end)
-
-      assert.are.same({ "a/b.ts", "x/a/b.ts", "n/b.ts", "c/b.ts" }, res)
     end)
   end)
 
   describe("sort_buffers", function()
-    it("should sort by filename", function()
+    it("should sort by unique_name", function()
       ---@type Buffer[]
       local bufs = {
         {
-          buf = 4,
-          _unique_name = "some.test",
-          ext = "ts",
-        },
-        {
           buf = 6,
-          _unique_name = "main",
+          _filename = "main",
+          _unique_name = "c/d/main",
           ext = "ts",
         },
         {
           buf = 5,
-          _unique_name = "some",
+          _filename = "some",
+          _unique_name = "z/some",
+          ext = "ts",
+        },
+        {
+          buf = 4,
+          _filename = "some.test",
+          _unique_name = "a/some.test",
+          ext = "ts",
+        },
+      }
+
+      local res =
+        utils.sort_buffers(bufs, { type = constants.SORT_TYPE.UNIQUE_NAME, direction = constants.SORT_DIRECTION.ASC })
+
+      res = list.map(bufs, function(item)
+        return item._unique_name
+      end)
+
+      assert.are.same(res, { "a/some.test", "c/d/main", "z/some" })
+    end)
+
+    it("should sort by filename", function()
+      ---@type Buffer[]
+      local bufs = {
+        {
+          buf = 6,
+          _filename = "main",
+          _unique_name = "c/d/main",
+          ext = "ts",
+        },
+        {
+          buf = 5,
+          _filename = "some",
+          _unique_name = "z/some",
+          ext = "ts",
+        },
+        {
+          buf = 4,
+          _filename = "some.test",
+          _unique_name = "a/some.test",
           ext = "ts",
         },
       }
@@ -275,7 +317,7 @@ describe("utils", function()
         utils.sort_buffers(bufs, { type = constants.SORT_TYPE.FILENAME, direction = constants.SORT_DIRECTION.ASC })
 
       res = list.map(bufs, function(item)
-        return item._unique_name
+        return item._filename
       end)
 
       assert.are.same(res, { "main", "some", "some.test" })


### PR DESCRIPTION
This PR addresses an issue where sorting by filename was not working as intended. With this update, the functionality to properly sort by filename has been fixed and the ability to **actually** sort by unique name has been added.