### PR TITLE
feat: custom ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ With this plugin, I aim to provide a solution that addresses these specific need
   - saved and restored per cwd
 - Rename buffer "display name" (not actual filename)
   - it is persisted if you use session
+- Reorder buffer
+  - the order is is persisted if you use session
 
 <br>
 
@@ -63,6 +65,8 @@ https://github.com/Hajime-Suzuki/vuffers.nvim/assets/26042720/3170217d-95ec-45dd
 Rename
 
 https://github.com/Hajime-Suzuki/vuffers.nvim/assets/26042720/f7ed8bff-42f4-4d28-8350-87291d2f55c5
+
+Reorder
 
 <br>
 
@@ -117,6 +121,9 @@ return {
           rename = "r",
           reset_custom_display_name = "R",
           reset_custom_display_names = "<leader>R",
+          move_up = "U",
+          move_down = "D",
+          move_to = "i",
         },
       },
       sort = {
@@ -194,15 +201,18 @@ vim.api.nvim_create_autocmd("SessionLoadPost", {
 
 UI actions are available only inside the vuffers window, and the target is the buffer under the cursor. See `keymaps.view` in the config.
 
-| function                     | description                                  |
-| ---------------------------- | -------------------------------------------- |
-| `open`                       | open the buffer                              |
-| `delete`                     | close the buffer                             |
-| `pin`                        |                                              |
-| `unpin`                      |                                              |
-| `rename`                     | rename the buffer, popup asks you a new name |
-| `reset_custom_display_name`  |                                              |
-| `reset_custom_display_names` | reset all display names                      |
+| function                     | description                                                                                                     |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `open`                       | open the buffer                                                                                                 |
+| `delete`                     | close the buffer                                                                                                |
+| `pin`                        |                                                                                                                 |
+| `unpin`                      |                                                                                                                 |
+| `rename`                     | rename the buffer, popup asks you a new name                                                                    |
+| `reset_custom_display_name`  |                                                                                                                 |
+| `reset_custom_display_names` | reset all display names                                                                                         |
+| `move_up`                    | move up the buffer by one (also support v count)                                                                |
+| `move_down`                  | move down the buffer by one (also support v count)                                                              |
+| `move_to`                    | move the buffer to the specified index. For example, `5i` moves the buffer under the cursor to the 5th position |
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ https://github.com/Hajime-Suzuki/vuffers.nvim/assets/26042720/f7ed8bff-42f4-4d28
 
 Reorder
 
+https://github.com/Hajime-Suzuki/vuffers.nvim/assets/26042720/e3a042a6-a4a3-4d91-af2b-d67f81de1ea6
+
+
+
 <br>
 
 ## ❗ Requirements

--- a/lua/utils/file.lua
+++ b/lua/utils/file.lua
@@ -1,3 +1,5 @@
+local str = require("utils.string")
+
 local M = {}
 
 function _ensure_file(filename)
@@ -21,6 +23,11 @@ end
 function M.write_json_file(filename, data)
   _ensure_file(filename)
   vim.fn.writefile({ vim.fn.json_encode(data) }, filename)
+end
+
+function M.cwd_name()
+  local cwd = vim.loop.cwd()
+  return str.replace(cwd, "/", "_")
 end
 
 return M

--- a/lua/vuffers.lua
+++ b/lua/vuffers.lua
@@ -211,12 +211,14 @@ end
 ------------------------------------
 
 function M.on_session_loaded()
+  config.load_saved_config()
   bufs.restore_buffers()
   bufs.set_is_restored_from_session(true)
 end
 
 function M.debug_buffers()
   bufs.debug_buffers()
+  print(vim.inspect(config.get_config()))
 end
 
 ---@param level LogLevel

--- a/lua/vuffers.lua
+++ b/lua/vuffers.lua
@@ -143,9 +143,16 @@ end
 
 ---@param args { direction: 'next' | 'prev', count?: integer }
 function M.move_current_buffer_by_count(args)
-  logger.debug("move_buffer: start")
+  logger.debug("move_current_buffer_by_count: start")
   bufs.move_current_buffer_by_count(args)
-  logger.info("move_buffer: done")
+  logger.info("move_current_buffer_by_count: done")
+end
+
+---@param args? { index?: integer }
+function M.move_current_buffer_to_index(args)
+  logger.debug("move_current_buffer_to_index: start")
+  bufs.move_current_buffer_to_index(args)
+  logger.info("move_current_buffer_to_index: done")
 end
 
 -- might be deprecated in the future

--- a/lua/vuffers.lua
+++ b/lua/vuffers.lua
@@ -141,6 +141,13 @@ function M.close_unpinned_buffers()
   bufs.remove_unpinned_buffers()
 end
 
+---@param args { direction: 'next' | 'prev', count?: integer }
+function M.move_current_buffer_by_count(args)
+  logger.debug("move_buffer: start")
+  bufs.move_current_buffer_by_count(args)
+  logger.info("move_buffer: done")
+end
+
 -- might be deprecated in the future
 function M.go_to_active_pinned_buffer()
   logger.debug("go_to_active_pinned_buffer: start")

--- a/lua/vuffers/auto-commands.lua
+++ b/lua/vuffers/auto-commands.lua
@@ -4,6 +4,7 @@ local ui = require("vuffers.ui")
 local buffers = require("vuffers.buffers")
 local window = require("vuffers.window")
 local buf_utils = require("vuffers.buffers.buffer-utils")
+local config = require("vuffers.config")
 
 local M = {}
 
@@ -126,6 +127,7 @@ function M.create_auto_group()
       if buffers.is_restored_from_session() then
         buffers.persist_buffers()
       end
+      config.persist_config()
     end,
   })
 end

--- a/lua/vuffers/buffers/buffer-utils.lua
+++ b/lua/vuffers/buffers/buffer-utils.lua
@@ -17,7 +17,7 @@ function M._get_name_by_level(path_fragments, level)
   return table.concat(filenames, "/")
 end
 
---- @param buffers { level: string, path_fragments: string[]}[]
+--- @param buffers { buf: integer, level: string, path_fragments: string[]}[]
 local function _get_unique_folder_depth(buffers, output)
   local grouped_by_filename = list.group_by(buffers, function(item)
     return item.path_fragments[#item.path_fragments - item.level + 1]
@@ -29,7 +29,7 @@ local function _get_unique_folder_depth(buffers, output)
     local is_unique = #items == 1 -- if the group has only one item then it is unique
 
     if is_unique then
-      table.insert(output, items[1])
+      output[items[1].buf] = items[1]
       goto continue
     end
 
@@ -37,7 +37,7 @@ local function _get_unique_folder_depth(buffers, output)
       local parent = item.path_fragments[#item.path_fragments - item.level]
 
       if parent == nil then -- when there is no parent, use the item as it is
-        table.insert(output, item)
+        output[item.buf] = item
       else
         item.level = item.level + 1
         table.insert(next_items, item)
@@ -128,7 +128,12 @@ function M.get_formatted_buffers(buffers)
 
   --- getting the unique folder depths, which is used to calculate the unique names
   _get_unique_folder_depth(input, output)
-  return list.map(output, _format_buffer)
+
+  --- the output should be sorted in the original order
+  return list.map(input, function(item)
+    local target = output[item.buf]
+    return _format_buffer(target)
+  end)
 end
 
 --- @param buffers Buffer[]
@@ -168,6 +173,10 @@ end
 --- @param buffers Buffer[]
 --- @param sort SortOrder
 function M.sort_buffers(buffers, sort)
+  if sort.type == constants.SORT_TYPE.__CUSTOM then
+    return buffers
+  end
+
   -- TODO: remove dependency
   local pinned = require("vuffers.buffers.pinned-buffers")
   return order_by(buffers, {

--- a/lua/vuffers/buffers/buffers.lua
+++ b/lua/vuffers/buffers/buffers.lua
@@ -189,6 +189,25 @@ function M.change_sort()
   _buf_list = utils.sort_buffers(_buf_list, config.get_sort())
 end
 
+---@param args {origin_index: number, target_index: number}
+function M.move_buffer(args)
+  local origin_buf = _buf_list[args.origin_index]
+  local target_buf = _buf_list[args.target_index]
+
+  if args.target_index == args.origin_index then
+    return logger.warn("move_buffer: target is the same as origin", args)
+  end
+
+  if not origin_buf or not target_buf then
+    return logger.warn("move_buffer: buffer not found", args)
+  end
+
+  table.remove(_buf_list, args.origin_index)
+  table.insert(_buf_list, args.target_index, origin_buf)
+
+  return true
+end
+
 ---@param new_level integer
 local function _change_additional_folder_depth(new_level)
   if new_level == _global_additional_folder_depth then

--- a/lua/vuffers/buffers/buffers.lua
+++ b/lua/vuffers/buffers/buffers.lua
@@ -120,7 +120,7 @@ function M.reset_custom_display_names()
     return buf._custom_name ~= nil
   end)
 
-  if not bufs_with_custom_name or not #bufs_with_custom_name then
+  if not bufs_with_custom_name or not next(bufs_with_custom_name) then
     return
   end
 

--- a/lua/vuffers/buffers/buffers.lua
+++ b/lua/vuffers/buffers/buffers.lua
@@ -264,19 +264,16 @@ end
 function M.add_buffer_by_file_path(file_paths)
   local bufs = _get_loaded_bufs()
 
-  ---@type {[string]: { path: string, _custom_name:string }[]}
-  local path_map = list.group_by(file_paths, function(file_path)
-    return file_path.path
+  ---@type {[string]: {buf: Bufnr, name: string, path: string, filetype: string, _additional_folder_depth: integer}[]}
+  local buf_map = list.group_by(bufs, function(buf)
+    return buf.path
   end)
 
-  ---@type ({ buf: Bufnr, name: string, path: string, filetype: string, _additional_folder_depth: integer } | nil)[]
-  local bufs_to_add = list.map(bufs, function(buf)
-    if not utils.is_valid_buf(buf) then
-      return nil
-    end
+  local bufs_to_add = list.map(file_paths, function(file_path)
+    -- buffers are grouped by file path, so there should be only 1 item in the list
+    local buf = buf_map[file_path.path] and buf_map[file_path.path][1]
 
-    local data = path_map[buf.path]
-    if not data then
+    if not buf or not utils.is_valid_buf(buf) then
       return nil
     end
 
@@ -286,7 +283,7 @@ function M.add_buffer_by_file_path(file_paths)
       path = buf.path,
       filetype = buf.filetype,
       _additional_folder_depth = buf._additional_folder_depth,
-      _custom_name = data[1]._custom_name,
+      _custom_name = file_path._custom_name,
     }
   end)
   bufs_to_add = list.filter(bufs_to_add, function(buf)

--- a/lua/vuffers/buffers/init.lua
+++ b/lua/vuffers/buffers/init.lua
@@ -203,7 +203,7 @@ end
 ------------------------------------
 ---
 ---@param args {origin_index: number, target_index: number}
-local _move_buffer = function(args)
+M.move_buffer = function(args)
   local target_buf = bufs.get_buffer_by_index(args.target_index)
   local origin_buf = bufs.get_buffer_by_index(args.origin_index)
 
@@ -224,11 +224,17 @@ local _move_buffer = function(args)
   if bufs.move_buffer(args) then
     local payload = event_payload.get_buffer_list_changed_event_payload()
     event_bus.publish_buffer_list_changed(payload)
+    return true
   end
 end
 
----@param args {index: number}
+---@param args? {index?: number}
 function M.move_current_buffer_to_index(args)
+  local index = (args and args.index) or vim.v.count
+  if not index or index == 0 then
+    return
+  end
+
   local current_buf_path = active.get_active_buf_path()
   if not current_buf_path then
     return logger.warn("move_current_buffer_to_index: buffer not found", args)
@@ -240,7 +246,7 @@ function M.move_current_buffer_to_index(args)
     return logger.warn("move_current_buffer_to_index: buffer not found", args)
   end
 
-  _move_buffer({ target_index = args.index, origin_index = origin_index })
+  M.move_buffer({ target_index = index, origin_index = origin_index })
 end
 
 ---@param args {direction: 'next' | 'prev', count?: integer}
@@ -262,7 +268,7 @@ function M.move_current_buffer_by_count(args)
 
   local target_index = origin_index + count
 
-  _move_buffer({ target_index = target_index, origin_index = origin_index })
+  M.move_buffer({ target_index = target_index, origin_index = origin_index })
 end
 
 ------------------------------------

--- a/lua/vuffers/buffers/init.lua
+++ b/lua/vuffers/buffers/init.lua
@@ -227,17 +227,33 @@ local _move_buffer = function(args)
   end
 end
 
----@param args {direction: 'next' | 'prev', count?: integer}
-function M.move_current_buffer_by_count(args)
+---@param args {index: number}
+function M.move_current_buffer_to_index(args)
   local current_buf_path = active.get_active_buf_path()
   if not current_buf_path then
-    return logger.warn("move_current_buffer: buffer not found", args)
+    return logger.warn("move_current_buffer_to_index: buffer not found", args)
   end
 
   local _, origin_index = bufs.get_buffer_by_path(current_buf_path)
 
   if not origin_index then
-    return logger.warn("move_current_buffer: buffer not found", args)
+    return logger.warn("move_current_buffer_to_index: buffer not found", args)
+  end
+
+  _move_buffer({ target_index = args.index, origin_index = origin_index })
+end
+
+---@param args {direction: 'next' | 'prev', count?: integer}
+function M.move_current_buffer_by_count(args)
+  local current_buf_path = active.get_active_buf_path()
+  if not current_buf_path then
+    return logger.warn("move_current_buffer_by_count: buffer not found", args)
+  end
+
+  local _, origin_index = bufs.get_buffer_by_path(current_buf_path)
+
+  if not origin_index then
+    return logger.warn("move_current_buffer_by_count: buffer not found", args)
   end
 
   local count = args.count or vim.v.count

--- a/lua/vuffers/buffers/init.lua
+++ b/lua/vuffers/buffers/init.lua
@@ -106,6 +106,10 @@ M.set_active_buf = function(buf)
   event_bus.publish_active_buffer_changed(payload)
 end
 
+------------------------------------
+--   PINNED BUFS                --
+------------------------------------
+
 M.get_active_pinned_buf_path = pinned.get_active_pinned_buf_path
 
 ---@param index integer
@@ -189,6 +193,27 @@ end
 
 M.get_next_or_prev_pinned_buffer = pinned.get_next_or_prev_pinned_buffer
 
+---@param buffer Buffer | NativeBuffer
+M.is_pinned = function(buffer)
+  return pinned.is_pinned(buffer.path or buffer.file)
+end
+
+------------------------------------
+--   CUSTOM ORDER             --
+------------------------------------
+
+---@param args {origin_index: number, target_index: number}
+M.move_buffer = function(args)
+  if bufs.move_buffer(args) then
+    local payload = event_payload.get_buffer_list_changed_event_payload()
+    event_bus.publish_buffer_list_changed(payload)
+  end
+end
+
+------------------------------------
+--   MISC                       --
+------------------------------------
+
 M.debug_buffers = function()
   local active_buf_path = active.get_active_buf_path()
   ---@diagnostic disable-next-line: cast-local-type
@@ -203,11 +228,6 @@ M.debug_buffers = function()
   )
   print("pinned buffers", vim.inspect(pinned.get_pinned_bufs()))
   print("buffers", vim.inspect(bufs.get_buffers()))
-end
-
----@param buffer Buffer | NativeBuffer
-M.is_pinned = function(buffer)
-  return pinned.is_pinned(buffer.path or buffer.file)
 end
 
 --------- persistence ---------

--- a/lua/vuffers/buffers/init.lua
+++ b/lua/vuffers/buffers/init.lua
@@ -224,6 +224,7 @@ M.move_buffer = function(args)
   if bufs.move_buffer(args) then
     local payload = event_payload.get_buffer_list_changed_event_payload()
     event_bus.publish_buffer_list_changed(payload)
+    config.set_sort({ type = "custom" })
     return true
   end
 end

--- a/lua/vuffers/buffers/init.lua
+++ b/lua/vuffers/buffers/init.lua
@@ -201,9 +201,9 @@ end
 ------------------------------------
 --   CUSTOM ORDER             --
 ------------------------------------
-
+---
 ---@param args {origin_index: number, target_index: number}
-M.move_buffer = function(args)
+local _move_buffer = function(args)
   local target_buf = bufs.get_buffer_by_index(args.target_index)
   local origin_buf = bufs.get_buffer_by_index(args.origin_index)
 
@@ -225,6 +225,28 @@ M.move_buffer = function(args)
     local payload = event_payload.get_buffer_list_changed_event_payload()
     event_bus.publish_buffer_list_changed(payload)
   end
+end
+
+---@param args {direction: 'next' | 'prev', count?: integer}
+function M.move_current_buffer_by_count(args)
+  local current_buf_path = active.get_active_buf_path()
+  if not current_buf_path then
+    return logger.warn("move_current_buffer: buffer not found", args)
+  end
+
+  local _, origin_index = bufs.get_buffer_by_path(current_buf_path)
+
+  if not origin_index then
+    return logger.warn("move_current_buffer: buffer not found", args)
+  end
+
+  local count = args.count or vim.v.count
+  count = count == 0 and 1 or count
+  count = args.direction == "next" and count or -count
+
+  local target_index = origin_index + count
+
+  _move_buffer({ target_index = target_index, origin_index = origin_index })
 end
 
 ------------------------------------

--- a/lua/vuffers/buffers/init.lua
+++ b/lua/vuffers/buffers/init.lua
@@ -204,6 +204,23 @@ end
 
 ---@param args {origin_index: number, target_index: number}
 M.move_buffer = function(args)
+  local target_buf = bufs.get_buffer_by_index(args.target_index)
+  local origin_buf = bufs.get_buffer_by_index(args.origin_index)
+
+  if not origin_buf or not target_buf then
+    return logger.warn("move_buffer: buffer not found", args)
+  end
+
+  if not pinned.is_pinned(origin_buf.path) and pinned.is_pinned(target_buf.path) then
+    logger.warn("move_buffer: can not move unpinned buffer to pinned buffers area", args)
+    return
+  end
+
+  if pinned.is_pinned(origin_buf.path) and not pinned.is_pinned(target_buf.path) then
+    logger.warn("move_buffer: can not move pinned buffer to unpinned buffers area", args)
+    return
+  end
+
   if bufs.move_buffer(args) then
     local payload = event_payload.get_buffer_list_changed_event_payload()
     event_bus.publish_buffer_list_changed(payload)

--- a/lua/vuffers/buffers/persist.lua
+++ b/lua/vuffers/buffers/persist.lua
@@ -35,8 +35,7 @@ function M.persist_pinned_buffers()
   to_save = list.map(to_save or {}, function(buf)
     return { path = buf.path }
   end)
-
-  if not #to_save then
+  if not next(to_save) then
     return
   end
 
@@ -115,7 +114,7 @@ function M.restore_buffers_from_file()
     return
   end
 
-  if not #buffers then
+  if not next(buffers) then
     return
   end
 

--- a/lua/vuffers/buffers/persist.lua
+++ b/lua/vuffers/buffers/persist.lua
@@ -4,10 +4,9 @@ local str = require("utils.string")
 local list = require("utils.list")
 local bufs = require("vuffers.buffers.buffers")
 local pinned = require("vuffers.buffers.pinned-buffers")
+local constants = require("vuffers.constants")
 
 local M = {}
-
-local BUFFERS_FILE_LOCATION = vim.fn.stdpath("data") .. "/vuffers"
 
 local _is_restored_from_session = false
 M.is_restored_from_session = function()
@@ -21,9 +20,8 @@ end
 
 --------------pinned buffers ----------------
 local function _get_pinned_buffers_filename()
-  local cwd = vim.loop.cwd()
-  local filename = str.replace(cwd, "/", "_")
-  return BUFFERS_FILE_LOCATION .. "/" .. filename .. ".json"
+  local filename = file.cwd_name()
+  return constants.VUFFERS_FILE_LOCATION .. "/" .. filename .. ".json"
 end
 
 function M.persist_pinned_buffers()
@@ -77,9 +75,8 @@ end
 
 ---@return string
 local function _get_buffers_filename()
-  local cwd = vim.loop.cwd()
-  local filename = str.replace(cwd, "/", "_")
-  return BUFFERS_FILE_LOCATION .. "/" .. filename .. "_buffers" .. ".json"
+  local filename = file.cwd_name() .. "_buffers"
+  return constants.VUFFERS_FILE_LOCATION .. "/" .. filename .. ".json"
 end
 
 function M.persist_buffers()

--- a/lua/vuffers/config.lua
+++ b/lua/vuffers/config.lua
@@ -1,3 +1,6 @@
+local constants = require("vuffers.constants")
+local file = require("utils.file")
+
 local M = {}
 
 ---@class Exclude
@@ -86,6 +89,19 @@ end
 ---@param auto_resize boolean
 M.set_auto_resize = function(auto_resize)
   config.view.window.auto_resize = auto_resize
+end
+
+M.persist_config = function()
+  local filename = file.cwd_name() .. "_config"
+  local path = constants.VUFFERS_FILE_LOCATION .. "/" .. filename .. ".json"
+  local config_data = config.sort
+  local ok, err = pcall(function()
+    file.write_json_file(path, config_data)
+  end)
+
+  if not ok then
+    print("persist_config: ", err)
+  end
 end
 
 ---@param user_config Config

--- a/lua/vuffers/config.lua
+++ b/lua/vuffers/config.lua
@@ -94,7 +94,10 @@ end
 M.persist_config = function()
   local filename = file.cwd_name() .. "_config"
   local path = constants.VUFFERS_FILE_LOCATION .. "/" .. filename .. ".json"
-  local config_data = config.sort
+  local config_data = {
+    sort = config.sort,
+  }
+
   local ok, err = pcall(function()
     file.write_json_file(path, config_data)
   end)
@@ -102,6 +105,21 @@ M.persist_config = function()
   if not ok then
     print("persist_config: ", err)
   end
+end
+
+M.load_saved_config = function()
+  local filename = file.cwd_name() .. "_config"
+  local path = constants.VUFFERS_FILE_LOCATION .. "/" .. filename .. ".json"
+  local ok, data = pcall(function()
+    return file.read_json_file(path)
+  end)
+
+  if not ok then
+    print("load_config: ", data)
+    return nil
+  end
+
+  config = vim.tbl_deep_extend("force", config, { sort = data.sort })
 end
 
 ---@param user_config Config
@@ -154,6 +172,7 @@ function M.setup(user_config)
   }
 
   config = vim.tbl_deep_extend("force", default, user_config or {})
+  M.load_saved_config()
 end
 
 return M

--- a/lua/vuffers/config.lua
+++ b/lua/vuffers/config.lua
@@ -37,6 +37,7 @@ local M = {}
 --- @field reset_custom_display_names string
 --- @field move_up string
 --- @field move_down string
+--- @field move_to string
 
 ---@class Config
 ---@field debug DebugConfig
@@ -154,6 +155,7 @@ function M.setup(user_config)
         reset_custom_display_names = "<leader>R",
         move_up = "U",
         move_down = "D",
+        move_to = "i",
       },
     },
     sort = {

--- a/lua/vuffers/config.lua
+++ b/lua/vuffers/config.lua
@@ -22,7 +22,18 @@ local M = {}
 
 ---@class Keymaps
 ---@field use_default boolean
----@field view { open: string, delete: string, pin: string, unpin: string, rename:string, reset_custom_display_name: string, reset_custom_display_names: string }
+---@field view KeymapView
+
+--- @class KeymapView
+--- @field open string
+--- @field delete string
+--- @field pin string
+--- @field unpin string
+--- @field rename string
+--- @field reset_custom_display_name string
+--- @field reset_custom_display_names string
+--- @field move_up string
+--- @field move_down string
 
 ---@class Config
 ---@field debug DebugConfig
@@ -107,6 +118,8 @@ function M.setup(user_config)
         rename = "r",
         reset_custom_display_name = "R",
         reset_custom_display_names = "<leader>R",
+        move_up = "U",
+        move_down = "D",
       },
     },
     sort = {

--- a/lua/vuffers/constants.lua
+++ b/lua/vuffers/constants.lua
@@ -8,6 +8,7 @@ M.SORT_TYPE = {
   NONE = "none",
   FILENAME = "filename",
   UNIQUE_NAME = "unique-name",
+  __CUSTOM = "custom",
 }
 
 ---@enum SortDirection

--- a/lua/vuffers/constants.lua
+++ b/lua/vuffers/constants.lua
@@ -34,4 +34,6 @@ M.HIGHLIGHTS = {
   ACTIVE_PINNED_ICON = "VuffersActivePinnedIcon",
 }
 
+M.VUFFERS_FILE_LOCATION = vim.fn.stdpath("data") .. "/vuffers"
+
 return M

--- a/lua/vuffers/event-bus.lua
+++ b/lua/vuffers/event-bus.lua
@@ -43,7 +43,7 @@ function M.publish(event, payload)
   logger.debug("receiving event: " .. event, { event = event, payload = payload })
 
   local handlers = _subscribers[event]
-  if not handlers or not #handlers then
+  if not handlers or not next(handlers) then
     logger.debug("no handler found", { event = event })
     return
   end

--- a/lua/vuffers/key-bindings.lua
+++ b/lua/vuffers/key-bindings.lua
@@ -30,6 +30,14 @@ function M.setup(payload)
   vim.keymap.set("n", keymaps.view.reset_custom_display_name, actions.reset_custom_display_name, opts)
 
   vim.keymap.set("n", keymaps.view.reset_custom_display_names, actions.reset_custom_display_names, opts)
+
+  vim.keymap.set("n", keymaps.view.move_up, function()
+    actions.move_current_buffer_by_count({ direction = "prev" })
+  end, opts)
+
+  vim.keymap.set("n", keymaps.view.move_down, function()
+    actions.move_current_buffer_by_count({ direction = "next" })
+  end, opts)
 end
 
 return M

--- a/lua/vuffers/key-bindings.lua
+++ b/lua/vuffers/key-bindings.lua
@@ -38,6 +38,8 @@ function M.setup(payload)
   vim.keymap.set("n", keymaps.view.move_down, function()
     actions.move_current_buffer_by_count({ direction = "next" })
   end, opts)
+
+  vim.keymap.set("n", keymaps.view.move_to, actions.move_buffer_to_index, opts)
 end
 
 return M

--- a/lua/vuffers/ui-actions.lua
+++ b/lua/vuffers/ui-actions.lua
@@ -77,4 +77,25 @@ function M.reset_custom_display_names()
   buffers.reset_custom_display_names()
 end
 
+---@param args {direction: 'next' | 'prev', count?: integer}
+function M.move_current_buffer_by_count(args)
+  local count = args.count or vim.v.count or 0
+  count = count == 0 and 1 or count
+
+  local pos = vim.api.nvim_win_get_cursor(0)
+  local row = pos[1]
+  local col = pos[2]
+  local buf = buffers.get_buffer_by_index(row)
+
+  if not buf then
+    return
+  end
+
+  local target_index = row + (args.direction == "next" and count or -count)
+
+  if buffers.move_buffer({ origin_index = row, target_index = target_index }) then
+    vim.api.nvim_win_set_cursor(0, { target_index, col })
+  end
+end
+
 return M

--- a/lua/vuffers/ui-actions.lua
+++ b/lua/vuffers/ui-actions.lua
@@ -98,4 +98,24 @@ function M.move_current_buffer_by_count(args)
   end
 end
 
+function M.move_buffer_to_index()
+  local target_index = vim.v.count
+  if not target_index or target_index == 0 then
+    return
+  end
+
+  local pos = vim.api.nvim_win_get_cursor(0)
+  local row = pos[1]
+  local col = pos[2]
+  local buf = buffers.get_buffer_by_index(row)
+
+  if not buf then
+    return
+  end
+
+  if buffers.move_buffer({ origin_index = row, target_index = target_index }) then
+    vim.api.nvim_win_set_cursor(0, { target_index, col })
+  end
+end
+
 return M

--- a/lua/vuffers/ui.lua
+++ b/lua/vuffers/ui.lua
@@ -226,7 +226,7 @@ function M.render_buffers(payload)
 
   local buffers = payload.buffers
 
-  if not #buffers then
+  if not next(buffers) then
     return
   end
 

--- a/tests/buffer-utils_spec.lua
+++ b/tests/buffer-utils_spec.lua
@@ -406,5 +406,39 @@ describe("utils", function()
         assert.fail("failed")
       end
     end)
+
+    it("should not do anything if sort order is __CUSTOM", function()
+      pinned.__set_pinned_bufnrs({ "z/some", "c/d/main" })
+      ---@type Buffer[]
+      local bufs = {
+        {
+          buf = 4,
+          _filename = "some.test",
+          _unique_name = "a/some.test",
+          ext = "ts",
+          is_pinned = false,
+        },
+        {
+          buf = 6,
+          _filename = "some",
+          _unique_name = "c/d/main",
+          ext = "ts",
+          is_pinned = true,
+          path = "c/d/main",
+        },
+        {
+          buf = 2,
+          _filename = "foo",
+          _unique_name = "b/foo.ts",
+          ext = "ts",
+          is_pinned = false,
+        },
+      }
+
+      local res =
+        utils.sort_buffers(bufs, { type = constants.SORT_TYPE.__CUSTOM, direction = constants.SORT_DIRECTION.ASC })
+
+      assert.are.same(res, bufs)
+    end)
   end)
 end)

--- a/tests/buffers_spec.lua
+++ b/tests/buffers_spec.lua
@@ -426,7 +426,7 @@ describe("buffers >>", function()
 
       event_bus.subscribe(event_bus.event.BufferListChanged, f, { label = "test" })
 
-      -- AND currently buf 1 is active
+      -- AND currently buf 4 is active
       buffers.set_active_buf(target_buf)
 
       local original_bufs = vim.fn.deepcopy(_bufs.get_buffers())
@@ -534,7 +534,7 @@ describe("buffers >>", function()
 
       event_bus.subscribe(event_bus.event.BufferListChanged, f, { label = "test" })
 
-      -- AND currently buf 1 is active
+      -- AND currently buf 4 is active
       buffers.set_active_buf(target_buf)
 
       -- WHEN move buffer 4 up by 2
@@ -556,17 +556,16 @@ describe("buffers >>", function()
         _updated_bufs = bufs
       end
 
-      local target_buf = create_buffer({ file = "test/something.ts", buf = 4 })
-
       -- GIVEN there are buffers
       buffers.add_buffer(create_buffer({ file = "a/b/c/test.json", buf = 1 }))
       buffers.add_buffer(create_buffer({ file = "foo.lua", buf = 2 }))
       buffers.add_buffer(create_buffer({ file = "bar.lua", buf = 3 }))
+      local target_buf = create_buffer({ file = "test/something.ts", buf = 4 })
       buffers.add_buffer(target_buf)
 
       event_bus.subscribe(event_bus.event.BufferListChanged, f, { label = "test" })
 
-      -- AND currently buf 1 is active
+      -- AND currently buf 4 is active
       buffers.set_active_buf(target_buf)
 
       -- WHEN move buffer 4 up
@@ -577,6 +576,45 @@ describe("buffers >>", function()
         return buf.buf
       end)
       assert.are.same({ 1, 2, 4, 3 }, updated_order)
+
+      -- TODO: AND sort order becomes "custom"
+    end)
+  end)
+
+  describe("move_current_buffer_to_index >>", function()
+    before_each(function()
+      event_bus._delete_all_subscriptions()
+      _bufs.set_buffers({})
+      pinned_bufs.__reset_pinned_bufnrs()
+    end)
+
+    it("should change order by count when count is passed", function()
+      ---@type BufferListChangedPayload
+      local _updated_bufs = {}
+      local f = function(bufs)
+        _updated_bufs = bufs
+      end
+
+      -- GIVEN there are buffers
+      buffers.add_buffer(create_buffer({ file = "a/b/c/test.json", buf = 1 }))
+      buffers.add_buffer(create_buffer({ file = "foo.lua", buf = 2 }))
+      buffers.add_buffer(create_buffer({ file = "bar.lua", buf = 3 }))
+      local target_buf = create_buffer({ file = "test/something.ts", buf = 4 })
+      buffers.add_buffer(target_buf)
+
+      event_bus.subscribe(event_bus.event.BufferListChanged, f, { label = "test" })
+
+      -- AND currently buf 4 is active
+      buffers.set_active_buf(target_buf)
+
+      -- WHEN move buffer 4 to position 2
+      buffers.move_current_buffer_to_index({ index = 2 })
+
+      -- THEN buffer is in new order
+      local updated_order = list.map(_updated_bufs.buffers or {}, function(buf)
+        return buf.buf
+      end)
+      assert.are.same({ 1, 4, 2, 3 }, updated_order)
 
       -- TODO: AND sort order becomes "custom"
     end)

--- a/tests/buffers_spec.lua
+++ b/tests/buffers_spec.lua
@@ -500,6 +500,72 @@ describe("buffers >>", function()
       -- TODO: AND sort order becomes "custom"
     end)
 
+    it("should not move unpinned buffer to the pinned buffers area", function()
+      ---@type BufferListChangedPayload
+      local _updated_bufs = {}
+      local f = function(bufs)
+        _updated_bufs = bufs
+      end
+
+      -- GIVEN there are buffers
+      buffers.add_buffer(create_buffer({ file = "a/b/c/test.json", buf = 1 }))
+      buffers.add_buffer(create_buffer({ file = "foo.lua", buf = 2 }))
+      buffers.add_buffer(create_buffer({ file = "bar.lua", buf = 3 }))
+      buffers.add_buffer(create_buffer({ file = "test/something.ts", buf = 4 }))
+
+      -- AND buf 1 and buf 2 are pinned
+      buffers.pin_buffer(1)
+      buffers.pin_buffer(2)
+
+      local original_bufs = _bufs.get_buffers()
+      event_bus.subscribe(event_bus.event.BufferListChanged, f, { label = "test" })
+
+      -- WHEN target index is pinned buffers area
+      buffers.move_buffer({ origin_index = 4, target_index = 2 })
+
+      -- THEN no event is published
+      assert.are.same({}, _updated_bufs)
+
+      -- AND no buffer is moved
+      local bufs_after_move = _bufs.get_buffers()
+      assert.are.same(original_bufs, bufs_after_move)
+
+      -- TODO: AND sort order becomes "custom"
+    end)
+
+    it("should not move pinned buffer to the unpinned buffers area", function()
+      ---@type BufferListChangedPayload
+      local _updated_bufs = {}
+      local f = function(bufs)
+        _updated_bufs = bufs
+      end
+
+      -- GIVEN there are buffers
+      buffers.add_buffer(create_buffer({ file = "a/b/c/test.json", buf = 1 }))
+      buffers.add_buffer(create_buffer({ file = "foo.lua", buf = 2 }))
+      buffers.add_buffer(create_buffer({ file = "bar.lua", buf = 3 }))
+      buffers.add_buffer(create_buffer({ file = "test/something.ts", buf = 4 }))
+
+      -- AND buf 1 and buf 2 are pinned
+      buffers.pin_buffer(1)
+      buffers.pin_buffer(2)
+
+      local original_bufs = _bufs.get_buffers()
+      event_bus.subscribe(event_bus.event.BufferListChanged, f, { label = "test" })
+
+      -- WHEN target index is pinned buffers area
+      buffers.move_buffer({ origin_index = 1, target_index = 4 })
+
+      -- THEN no event is published
+      assert.are.same({}, _updated_bufs)
+
+      -- AND no buffer is moved
+      local bufs_after_move = _bufs.get_buffers()
+      assert.are.same(original_bufs, bufs_after_move)
+
+      -- TODO: AND sort order becomes "custom"
+    end)
+
     it("should change order", function()
       ---@type BufferListChangedPayload
       local _updated_bufs = {}

--- a/tests/buffers_spec.lua
+++ b/tests/buffers_spec.lua
@@ -403,14 +403,14 @@ describe("buffers >>", function()
     end)
   end)
 
-  describe("move_buffer >>", function()
+  describe("move_current_buffer_by_count >>", function()
     before_each(function()
       event_bus._delete_all_subscriptions()
       _bufs.set_buffers({})
       pinned_bufs.__reset_pinned_bufnrs()
     end)
 
-    it("should not change order if origin index is invalid", function()
+    it("should not change order if count is invalid", function()
       ---@type BufferListChangedPayload
       local _updated_bufs = {}
       local f = function(bufs)
@@ -421,74 +421,18 @@ describe("buffers >>", function()
       buffers.add_buffer(create_buffer({ file = "a/b/c/test.json", buf = 1 }))
       buffers.add_buffer(create_buffer({ file = "foo.lua", buf = 2 }))
       buffers.add_buffer(create_buffer({ file = "bar.lua", buf = 3 }))
-      buffers.add_buffer(create_buffer({ file = "test/something.ts", buf = 4 }))
-
-      local original_bufs = _bufs.get_buffers()
+      local target_buf = create_buffer({ file = "test/something.ts", buf = 4 })
+      buffers.add_buffer(target_buf)
 
       event_bus.subscribe(event_bus.event.BufferListChanged, f, { label = "test" })
+
+      -- AND currently buf 1 is active
+      buffers.set_active_buf(target_buf)
+
+      local original_bufs = vim.fn.deepcopy(_bufs.get_buffers())
 
       -- WHEN origin index is out of bounds
-      buffers.move_buffer({ origin_index = 5, target_index = 2 })
-
-      -- THEN no event is published
-      assert.are.same({}, _updated_bufs)
-
-      -- AND no buffer is moved
-      local bufs_after_move = _bufs.get_buffers()
-      assert.are.same(original_bufs, bufs_after_move)
-
-      -- TODO: AND sort order becomes "custom"
-    end)
-
-    it("should not change order if target index is invalid", function()
-      ---@type BufferListChangedPayload
-      local _updated_bufs = {}
-      local f = function(bufs)
-        _updated_bufs = bufs
-      end
-
-      -- GIVEN there are buffers
-      buffers.add_buffer(create_buffer({ file = "a/b/c/test.json", buf = 1 }))
-      buffers.add_buffer(create_buffer({ file = "foo.lua", buf = 2 }))
-      buffers.add_buffer(create_buffer({ file = "bar.lua", buf = 3 }))
-      buffers.add_buffer(create_buffer({ file = "test/something.ts", buf = 4 }))
-
-      local original_bufs = _bufs.get_buffers()
-
-      event_bus.subscribe(event_bus.event.BufferListChanged, f, { label = "test" })
-
-      -- WHEN target index is out of bounds
-      buffers.move_buffer({ origin_index = 1, target_index = 6 })
-
-      -- THEN no event is published
-      assert.are.same({}, _updated_bufs)
-
-      -- AND no buffer is moved
-      local bufs_after_move = _bufs.get_buffers()
-      assert.are.same(original_bufs, bufs_after_move)
-
-      -- TODO: AND sort order becomes "custom"
-    end)
-
-    it("should not change order if target index and origin index is the same", function()
-      ---@type BufferListChangedPayload
-      local _updated_bufs = {}
-      local f = function(bufs)
-        _updated_bufs = bufs
-      end
-
-      -- GIVEN there are buffers
-      buffers.add_buffer(create_buffer({ file = "a/b/c/test.json", buf = 1 }))
-      buffers.add_buffer(create_buffer({ file = "foo.lua", buf = 2 }))
-      buffers.add_buffer(create_buffer({ file = "bar.lua", buf = 3 }))
-      buffers.add_buffer(create_buffer({ file = "test/something.ts", buf = 4 }))
-
-      local original_bufs = _bufs.get_buffers()
-
-      event_bus.subscribe(event_bus.event.BufferListChanged, f, { label = "test" })
-
-      -- WHEN target index is the same as origin index
-      buffers.move_buffer({ origin_index = 1, target_index = 1 })
+      buffers.move_current_buffer_by_count({ direction = "next", count = 1 })
 
       -- THEN no event is published
       assert.are.same({}, _updated_bufs)
@@ -511,17 +455,21 @@ describe("buffers >>", function()
       buffers.add_buffer(create_buffer({ file = "a/b/c/test.json", buf = 1 }))
       buffers.add_buffer(create_buffer({ file = "foo.lua", buf = 2 }))
       buffers.add_buffer(create_buffer({ file = "bar.lua", buf = 3 }))
-      buffers.add_buffer(create_buffer({ file = "test/something.ts", buf = 4 }))
+      local target_buf = create_buffer({ file = "test/something.ts", buf = 4 })
+      buffers.add_buffer(target_buf)
 
       -- AND buf 1 and buf 2 are pinned
       buffers.pin_buffer(1)
       buffers.pin_buffer(2)
 
-      local original_bufs = _bufs.get_buffers()
+      -- AND currently buf 4 is active
+      buffers.set_active_buf(target_buf)
+
       event_bus.subscribe(event_bus.event.BufferListChanged, f, { label = "test" })
+      local original_bufs = vim.fn.deepcopy(_bufs.get_buffers())
 
       -- WHEN target index is pinned buffers area
-      buffers.move_buffer({ origin_index = 4, target_index = 2 })
+      buffers.move_current_buffer_by_count({ direction = "prev", count = 2 })
 
       -- THEN no event is published
       assert.are.same({}, _updated_bufs)
@@ -541,7 +489,8 @@ describe("buffers >>", function()
       end
 
       -- GIVEN there are buffers
-      buffers.add_buffer(create_buffer({ file = "a/b/c/test.json", buf = 1 }))
+      local target_buf = create_buffer({ file = "a/b/c/test.json", buf = 1 })
+      buffers.add_buffer(target_buf)
       buffers.add_buffer(create_buffer({ file = "foo.lua", buf = 2 }))
       buffers.add_buffer(create_buffer({ file = "bar.lua", buf = 3 }))
       buffers.add_buffer(create_buffer({ file = "test/something.ts", buf = 4 }))
@@ -550,11 +499,14 @@ describe("buffers >>", function()
       buffers.pin_buffer(1)
       buffers.pin_buffer(2)
 
-      local original_bufs = _bufs.get_buffers()
+      -- AND currently buf 1 is active
+      buffers.set_active_buf(target_buf)
       event_bus.subscribe(event_bus.event.BufferListChanged, f, { label = "test" })
 
-      -- WHEN target index is pinned buffers area
-      buffers.move_buffer({ origin_index = 1, target_index = 4 })
+      local original_bufs = vim.fn.deepcopy(_bufs.get_buffers())
+
+      -- WHEN target index is unpinned buffers area
+      buffers.move_current_buffer_by_count({ direction = "next", count = 2 })
 
       -- THEN no event is published
       assert.are.same({}, _updated_bufs)
@@ -566,7 +518,7 @@ describe("buffers >>", function()
       -- TODO: AND sort order becomes "custom"
     end)
 
-    it("should change order", function()
+    it("should change order by count when count is passed", function()
       ---@type BufferListChangedPayload
       local _updated_bufs = {}
       local f = function(bufs)
@@ -577,18 +529,54 @@ describe("buffers >>", function()
       buffers.add_buffer(create_buffer({ file = "a/b/c/test.json", buf = 1 }))
       buffers.add_buffer(create_buffer({ file = "foo.lua", buf = 2 }))
       buffers.add_buffer(create_buffer({ file = "bar.lua", buf = 3 }))
-      buffers.add_buffer(create_buffer({ file = "test/something.ts", buf = 4 }))
+      local target_buf = create_buffer({ file = "test/something.ts", buf = 4 })
+      buffers.add_buffer(target_buf)
 
       event_bus.subscribe(event_bus.event.BufferListChanged, f, { label = "test" })
 
-      -- WHEN move buffer 4 to the 2nd position
-      buffers.move_buffer({ origin_index = 4, target_index = 2 })
+      -- AND currently buf 1 is active
+      buffers.set_active_buf(target_buf)
+
+      -- WHEN move buffer 4 up by 2
+      buffers.move_current_buffer_by_count({ direction = "prev", count = 2 })
+
+      -- THEN buffer is in new order
+      local updated_order = list.map(_updated_bufs.buffers or {}, function(buf)
+        return buf.buf
+      end)
+      assert.are.same({ 1, 4, 2, 3 }, updated_order)
+
+      -- TODO: AND sort order becomes "custom"
+    end)
+
+    it("should change order by 1 when count is not passed", function()
+      ---@type BufferListChangedPayload
+      local _updated_bufs = {}
+      local f = function(bufs)
+        _updated_bufs = bufs
+      end
+
+      local target_buf = create_buffer({ file = "test/something.ts", buf = 4 })
+
+      -- GIVEN there are buffers
+      buffers.add_buffer(create_buffer({ file = "a/b/c/test.json", buf = 1 }))
+      buffers.add_buffer(create_buffer({ file = "foo.lua", buf = 2 }))
+      buffers.add_buffer(create_buffer({ file = "bar.lua", buf = 3 }))
+      buffers.add_buffer(target_buf)
+
+      event_bus.subscribe(event_bus.event.BufferListChanged, f, { label = "test" })
+
+      -- AND currently buf 1 is active
+      buffers.set_active_buf(target_buf)
+
+      -- WHEN move buffer 4 up
+      buffers.move_current_buffer_by_count({ direction = "prev" })
 
       -- THEN buffer is in the new order
       local updated_order = list.map(_updated_bufs.buffers or {}, function(buf)
         return buf.buf
       end)
-      assert.are.same({ 1, 4, 2, 3 }, updated_order)
+      assert.are.same({ 1, 2, 4, 3 }, updated_order)
 
       -- TODO: AND sort order becomes "custom"
     end)


### PR DESCRIPTION
This PR introduces a custom ordering functionality. The following features are included:

- Buffers can be moved up and down
- Buffers can be moved to a specific index
- Pinned buffers can't move to the unpinned area and vice versa
- Reordering changes the sort order. Therefore, a newly opened buffers are placed at the bottom