### PR TITLE
feat: open in pre-existing window, same action on multiple keys, disable specific keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,14 @@ return {
         end,
       },
       keymaps = {
+        -- if false, no bindings will be provided at all
+        -- thus you will have to bind on your own
         use_default = true,
         -- key maps on the vuffers list
+        -- - may map multiple keys for the same action
+        --    open = { "<CR>", "<C-l>" }
+        -- - disable a specific binding using "false"
+        --    open = false
         view = {
           open = "<CR>",
           delete = "d",
@@ -178,7 +184,7 @@ vim.api.nvim_create_autocmd("SessionLoadPost", {
 
 | function                            | param                                                         | description                                                                                                                                         |
 | ----------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `open`                              |                                                               | open the vuffers window                                                                                                                             |
+| `open`                              | `{ win?: winid }`                                                              | open the vuffers window. If win is provided, re-uses the pre-existing window with winid = id                                     |
 | `close`                             |                                                               | close the vuffers window                                                                                                                            |
 | `toggle`                            |                                                               | toggle the vuffers window                                                                                                                           |
 | `is_open`                           |                                                               | return `true` if the vuffers window is open                                                                                                         |

--- a/lua/vuffers.lua
+++ b/lua/vuffers.lua
@@ -30,14 +30,16 @@ function M.is_open()
   return window.is_open()
 end
 
-function M.toggle()
+---@param opts? {win: integer}
+function M.toggle(opts)
   if window.is_open() then
     M.close()
   else
-    M.open()
+    M.open(opts)
   end
 end
 
+---@param opts? {win: integer}
 function M.open(opts)
   if window.is_open() then
     return

--- a/lua/vuffers.lua
+++ b/lua/vuffers.lua
@@ -38,14 +38,14 @@ function M.toggle()
   end
 end
 
-function M.open()
+function M.open(opts)
   if window.is_open() then
     return
   end
 
   logger.debug("M.open: start")
 
-  window.open()
+  window.open(opts)
 
   logger.debug("M.open: end")
 end

--- a/lua/vuffers/config.lua
+++ b/lua/vuffers/config.lua
@@ -28,16 +28,16 @@ local M = {}
 ---@field view KeymapView
 
 --- @class KeymapView
---- @field open string
---- @field delete string
---- @field pin string
---- @field unpin string
---- @field rename string
---- @field reset_custom_display_name string
---- @field reset_custom_display_names string
---- @field move_up string
---- @field move_down string
---- @field move_to string
+--- @field open string | string[]
+--- @field delete string | string[]
+--- @field pin string | string[]
+--- @field unpin string | string[]
+--- @field rename string | string[]
+--- @field reset_custom_display_name string | string[]
+--- @field reset_custom_display_names string | string[]
+--- @field move_up string | string[]
+--- @field move_down string | string[]
+--- @field move_to string | string[]
 
 ---@class Config
 ---@field debug DebugConfig

--- a/lua/vuffers/key-bindings.lua
+++ b/lua/vuffers/key-bindings.lua
@@ -2,9 +2,21 @@ local logger = require("utils.logger")
 local actions = require("vuffers.ui-actions")
 local config = require("vuffers.config")
 
+local lup_actions = {
+	open												= actions.open_buffer,
+	delete											= actions.delete_buffer,
+	pin													=	actions.pin_buffer,
+	unpin												= actions.unpin_buffer,
+	rename											= actions.rename_buffer,
+	reset_custom_display_name		= actions.reset_custom_display_name,
+	reset_custom_display_names	= actions.reset_custom_display_name,
+	move_up											= function() actions.move_current_buffer_by_count({ direction = "prev" }) end,
+	move_down										= function() actions.move_current_buffer_by_count({ direction = "next" }) end,
+	move_to											= actions.move_buffer_to_index
+}
+
 local M = {}
 
----@param payload VuffersWindowOpenedPayload
 function M.setup(payload)
   local bufnr = payload.buffer_number
   local keymaps = config.get_keymaps()
@@ -16,30 +28,13 @@ function M.setup(payload)
   logger.debug("setting key bindings", keymaps)
 
   local opts = { noremap = true, silent = true, nowait = true, buffer = bufnr }
-
-  vim.keymap.set("n", keymaps.view.open, actions.open_buffer, opts)
-
-  vim.keymap.set("n", keymaps.view.delete, actions.delete_buffer, opts)
-
-  vim.keymap.set("n", keymaps.view.pin, actions.pin_buffer, opts)
-
-  vim.keymap.set("n", keymaps.view.unpin, actions.unpin_buffer, opts)
-
-  vim.keymap.set("n", keymaps.view.rename, actions.rename_buffer, opts)
-
-  vim.keymap.set("n", keymaps.view.reset_custom_display_name, actions.reset_custom_display_name, opts)
-
-  vim.keymap.set("n", keymaps.view.reset_custom_display_names, actions.reset_custom_display_names, opts)
-
-  vim.keymap.set("n", keymaps.view.move_up, function()
-    actions.move_current_buffer_by_count({ direction = "prev" })
-  end, opts)
-
-  vim.keymap.set("n", keymaps.view.move_down, function()
-    actions.move_current_buffer_by_count({ direction = "next" })
-  end, opts)
-
-  vim.keymap.set("n", keymaps.view.move_to, actions.move_buffer_to_index, opts)
+	vim.iter(keymaps.view)
+		:each(function(rhs, lhsgroup)
+			vim.iter({ lhsgroup or nil }):flatten()
+				:each(function(lhs)
+					vim.keymap.set("n", lhs, lup_actions[rhs], opts)
+				end)
+		end)
 end
 
 return M

--- a/lua/vuffers/key-bindings.lua
+++ b/lua/vuffers/key-bindings.lua
@@ -17,6 +17,7 @@ local lup_actions = {
 
 local M = {}
 
+---@param payload VuffersWindowOpenedPayload
 function M.setup(payload)
   local bufnr = payload.buffer_number
   local keymaps = config.get_keymaps()

--- a/lua/vuffers/window.lua
+++ b/lua/vuffers/window.lua
@@ -110,6 +110,7 @@ function M.is_open()
   return window ~= nil
 end
 
+---@param opts? {win: integer}
 function M.open(opts)
 	opts = opts or { }
 
@@ -142,6 +143,7 @@ function M.close()
   _reset_view()
 end
 
+---@param opts? {win: integer}
 function M.toggle(opts)
   if M.is_open() then
     M.close()

--- a/lua/vuffers/window.lua
+++ b/lua/vuffers/window.lua
@@ -110,7 +110,9 @@ function M.is_open()
   return window ~= nil
 end
 
-function M.open()
+function M.open(opts)
+	opts = opts or { }
+
   local view = _get_view()
 
   if view then
@@ -118,7 +120,7 @@ function M.open()
     return
   end
 
-  local winnr = _create_window()
+  local winnr = opts.win or _create_window()
   local bufnr = _create_buffer()
   _set_view({ winnr = winnr, bufnr = bufnr })
 
@@ -140,11 +142,11 @@ function M.close()
   _reset_view()
 end
 
-function M.toggle()
+function M.toggle(opts)
   if M.is_open() then
     M.close()
   else
-    M.open()
+    M.open(opts)
   end
 end
 


### PR DESCRIPTION
This PR partially resolves what was requested in #39:
- May now bind the same action on multiple keys
- May now disable a specific keybinding by setting it to false
- May now open the vuffer in a specific pre-existing window (_could_ help in other APIs integration)
- related readme options were documented
- clarified what `use_default` actually meant, on first glance I thought it meant _excluding non explicitly set keys_

_Yet_ to attempt to implement the `last_used` , not sure there's a builtin function to get buffer "last edited" timestamp