### PR TITLE
feat: add an option to show extensions in filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ return {
       view = {
         modified_icon = "󰛿", -- when a buffer is modified, this icon will be shown
         pinned_icon = "󰐾",
+        show_file_extension = false,
         window = {
           auto_resize= false,
           width = 35,

--- a/lua/vuffers/buffers/buffer-utils.lua
+++ b/lua/vuffers/buffers/buffer-utils.lua
@@ -86,13 +86,14 @@ local function _format_buffer(item)
   local unique_name_without_extension, extension = _split_filename_and_extension(unique_name)
 
   local display_name = _get_display_name(item, unique_name)
-  local display_name_without_extension = _split_filename_and_extension(display_name)
+  local name = config.get_view_config().show_file_extension and display_name
+    or _split_filename_and_extension(display_name)
   local filename_without_extension = _split_filename_and_extension(item.path_fragments[#item.path_fragments])
 
   ---@type Buffer
   local b = {
     buf = item.buf,
-    name = display_name_without_extension,
+    name = name,
     path = item.path,
     ext = extension or "",
     _unique_name = unique_name_without_extension,

--- a/lua/vuffers/config.lua
+++ b/lua/vuffers/config.lua
@@ -22,6 +22,7 @@ local M = {}
 ---@field modified_icon string
 ---@field pinned_icon string
 ---@field window { auto_resize: boolean, width: number, focus_on_open: boolean }
+---@field show_file_extension boolean
 
 ---@class Keymaps
 ---@field use_default boolean
@@ -165,6 +166,7 @@ function M.setup(user_config)
     view = {
       modified_icon = "󰛿", -- when a buffer is modified, this icon will be shown
       pinned_icon = "󰃀",
+      show_file_extension = false,
       window = {
         auto_resize = false,
         width = 35,

--- a/lua/vuffers/ui.lua
+++ b/lua/vuffers/ui.lua
@@ -19,16 +19,19 @@ if not is_devicon_ok then
 end
 
 ---@param buffer Buffer
+---@return string
+local function _get_buffer_name_with_extenstion(buffer)
+  return string.match(buffer.name, "^%..+$") and buffer.name or buffer.name .. "." .. buffer.ext
+end
+
+---@param buffer Buffer
 ---@return string, string -- icon, highlight name
 local function _get_icon(buffer)
-  local buffer_name_with_extension = string.match(buffer.name, "^%..+$") and buffer.name
-    or buffer.name .. "." .. buffer.ext
-
   if not is_devicon_ok or not devicon.has_loaded() then
     return "", ""
   end
 
-  local icon, color = devicon.get_icon(buffer_name_with_extension, buffer.ext, { default = true })
+  local icon, color = devicon.get_icon(_get_buffer_name_with_extenstion(buffer), buffer.ext, { default = true })
   return icon or " ", color or ""
 end
 
@@ -49,7 +52,9 @@ local function _generate_line(buffer)
   local pinned_icon = config.get_view_config().pinned_icon
   local pinned_icon_text = bufs.is_pinned(buffer) and pinned_icon .. " " or ""
   local icon_text = icon ~= "" and icon .. " " or "  "
-  local text = pinned_icon_text .. icon_text .. buffer.name
+  local filename_text = config.get_view_config().show_file_extension and _get_buffer_name_with_extenstion(buffer)
+    or buffer.name
+  local text = pinned_icon_text .. icon_text .. filename_text
 
   ---@type Highlight[]
   local highlights = {}

--- a/lua/vuffers/ui.lua
+++ b/lua/vuffers/ui.lua
@@ -20,7 +20,7 @@ end
 
 ---@param buffer Buffer
 ---@return string
-local function _get_buffer_name_with_extenstion(buffer)
+local function _get_buffer_name_with_extension(buffer)
   return string.match(buffer.name, "^%..+$") and buffer.name or buffer.name .. "." .. buffer.ext
 end
 
@@ -31,7 +31,7 @@ local function _get_icon(buffer)
     return "", ""
   end
 
-  local icon, color = devicon.get_icon(_get_buffer_name_with_extenstion(buffer), buffer.ext, { default = true })
+  local icon, color = devicon.get_icon(_get_buffer_name_with_extension(buffer), buffer.ext, { default = true })
   return icon or " ", color or ""
 end
 
@@ -52,7 +52,7 @@ local function _generate_line(buffer)
   local pinned_icon = config.get_view_config().pinned_icon
   local pinned_icon_text = bufs.is_pinned(buffer) and pinned_icon .. " " or ""
   local icon_text = icon ~= "" and icon .. " " or "  "
-  local filename_text = config.get_view_config().show_file_extension and _get_buffer_name_with_extenstion(buffer)
+  local filename_text = config.get_view_config().show_file_extension and _get_buffer_name_with_extension(buffer)
     or buffer.name
   local text = pinned_icon_text .. icon_text .. filename_text
 

--- a/lua/vuffers/ui.lua
+++ b/lua/vuffers/ui.lua
@@ -19,19 +19,16 @@ if not is_devicon_ok then
 end
 
 ---@param buffer Buffer
----@return string
-local function _get_buffer_name_with_extension(buffer)
-  return string.match(buffer.name, "^%..+$") and buffer.name or buffer.name .. "." .. buffer.ext
-end
-
----@param buffer Buffer
 ---@return string, string -- icon, highlight name
 local function _get_icon(buffer)
+  local buffer_name_with_extension = string.match(buffer.name, "^%..+$") and buffer.name
+    or buffer.name .. "." .. buffer.ext
+
   if not is_devicon_ok or not devicon.has_loaded() then
     return "", ""
   end
 
-  local icon, color = devicon.get_icon(_get_buffer_name_with_extension(buffer), buffer.ext, { default = true })
+  local icon, color = devicon.get_icon(buffer_name_with_extension, buffer.ext, { default = true })
   return icon or " ", color or ""
 end
 
@@ -52,9 +49,7 @@ local function _generate_line(buffer)
   local pinned_icon = config.get_view_config().pinned_icon
   local pinned_icon_text = bufs.is_pinned(buffer) and pinned_icon .. " " or ""
   local icon_text = icon ~= "" and icon .. " " or "  "
-  local filename_text = config.get_view_config().show_file_extension and _get_buffer_name_with_extension(buffer)
-    or buffer.name
-  local text = pinned_icon_text .. icon_text .. filename_text
+  local text = pinned_icon_text .. icon_text .. buffer.name
 
   ---@type Highlight[]
   local highlights = {}


### PR DESCRIPTION
Add the option `show_file_extension` in the config to set the visibility of the files extensions.