### PR TITLE
fix: replace BufModifiedSet with OptionSet for Neovim 0.11 compat

### DIFF
--- a/lua/vuffers/auto-commands.lua
+++ b/lua/vuffers/auto-commands.lua
@@ -81,7 +81,7 @@ function M.create_auto_group()
     end,
   })
 
-  if vim.fn.has("nvim-0.13") == 1 then
+  if vim.fn.exists("##BufModifiedSet") == 1 then
     vim.api.nvim_create_autocmd({ "BufModifiedSet" }, {
       pattern = "*",
       group = constants.AUTO_CMD_GROUP,

--- a/lua/vuffers/auto-commands.lua
+++ b/lua/vuffers/auto-commands.lua
@@ -81,14 +81,14 @@ function M.create_auto_group()
     end,
   })
 
-  vim.api.nvim_create_autocmd({ "BufModifiedSet" }, {
-    pattern = "*",
+  vim.api.nvim_create_autocmd({ "OptionSet" }, {
+    pattern = "modified",
     group = constants.AUTO_CMD_GROUP,
     callback = function(buffer)
       if not buf_utils.is_valid_buf(buffer) then
         return
       end
-      logger.debug("BufModifiedSet", { buffer = buffer })
+      logger.debug("OptionSet modified", { buffer = buffer })
 
       ui.update_modified_icon(buffer)
     end,

--- a/lua/vuffers/auto-commands.lua
+++ b/lua/vuffers/auto-commands.lua
@@ -81,18 +81,31 @@ function M.create_auto_group()
     end,
   })
 
-  vim.api.nvim_create_autocmd({ "OptionSet" }, {
-    pattern = "modified",
-    group = constants.AUTO_CMD_GROUP,
-    callback = function(buffer)
-      if not buf_utils.is_valid_buf(buffer) then
-        return
-      end
-      logger.debug("OptionSet modified", { buffer = buffer })
-
-      ui.update_modified_icon(buffer)
-    end,
-  })
+  if vim.fn.has("nvim-0.13") == 1 then
+    vim.api.nvim_create_autocmd({ "BufModifiedSet" }, {
+      pattern = "*",
+      group = constants.AUTO_CMD_GROUP,
+      callback = function(buffer)
+        if not buf_utils.is_valid_buf(buffer) then
+          return
+        end
+        logger.debug("BufModifiedSet", { buffer = buffer })
+        ui.update_modified_icon(buffer)
+      end,
+    })
+  else
+    vim.api.nvim_create_autocmd({ "OptionSet" }, {
+      pattern = "modified",
+      group = constants.AUTO_CMD_GROUP,
+      callback = function(buffer)
+        if not buf_utils.is_valid_buf(buffer) then
+          return
+        end
+        logger.debug("OptionSet modified", { buffer = buffer })
+        ui.update_modified_icon(buffer)
+      end,
+    })
+  end
 
   vim.api.nvim_create_autocmd("BufWritePost", {
     pattern = "*",


### PR DESCRIPTION
BufModifiedSet was removed in Neovim 0.11. Replacing with OptionSet pattern=modified which has been available since Vim 7.4.729 so no version guard is needed.